### PR TITLE
Instrument http_queue_duration_seconds by looking at X-Request-Start headers

### DIFF
--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -23,9 +23,12 @@ class PrometheusExporter::Middleware
   end
 
   def call(env)
+    queue_time = measure_queue_time(env)
+
     MethodProfiler.start
     result = @app.call(env)
     info = MethodProfiler.stop
+
     result
   ensure
     status = (result && result[0]) || -1
@@ -39,9 +42,44 @@ class PrometheusExporter::Middleware
     @client.send_json(
       type: "web",
       timings: info,
+      queue_time: queue_time,
       action: action,
       controller: controller,
       status: status
     )
+  end
+
+  private
+
+  # measures the queue time (= time between receiving the request in downstream
+  # load balancer and starting request in ruby process)
+  def measure_queue_time(env)
+    start_time = queue_start(env)
+
+    return unless start_time
+
+    queue_time = request_start.to_f - start_time.to_f
+    queue_time unless queue_time.negative?
+  end
+
+  # need to use CLOCK_REALTIME, as nginx/apache write this also out as the unix timestamp
+  def request_start
+    Process.clock_gettime(Process::CLOCK_REALTIME)
+  end
+
+  # get the content of the x-queue-start or x-request-start header
+  def queue_start(env)
+    value = env['HTTP_X_REQUEST_START'] || env['HTTP_X_QUEUE_START']
+    unless value.nil? || value == ''
+      convert_header_to_ms(value.to_s)
+    end
+  end
+
+  # nginx returns time as milliseconds with 3 decimal places
+  # apache returns time as microseconds without decimal places
+  # this method takes care to convert both into a proper second + fractions timestamp
+  def convert_header_to_ms(str)
+    str = str.gsub(/t=|\./, '')
+    "#{str[0,10]}.#{str[10,13]}".to_f
   end
 end

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -42,6 +42,11 @@ module PrometheusExporter::Server
           "http_sql_duration_seconds",
           "Time spent in HTTP reqs in SQL in seconds"
         )
+
+        @metrics["http_queue_duration_seconds"] = @http_queue_duration_seconds = PrometheusExporter::Metric::Summary.new(
+          "http_queue_duration_seconds",
+          "Time spent queueing the request in load balancer in seconds"
+        )
       end
     end
 
@@ -62,6 +67,9 @@ module PrometheusExporter::Server
         if sql = timings["sql"]
           @http_sql_duration_seconds.observe(sql["duration"], labels)
         end
+      end
+      if queue_time = obj["queue_time"]
+        @http_queue_duration_seconds.observe(queue_time, labels)
       end
     end
   end

--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mini_racer", "~> 0.1"
   spec.add_development_dependency "guard-minitest", "~> 2.0"
   spec.add_development_dependency "oj", "~> 3.0"
+  spec.add_development_dependency "rack-test", "~> 0.8.3"
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+require 'rack/test'
+require 'prometheus_exporter/middleware'
+
+class PrometheusExporterMiddlewareTest < Minitest::Test
+  include Rack::Test::Methods
+
+  class FakeClient
+    attr_reader :last_send
+
+    def send_json(args)
+      @last_send = args
+    end
+  end
+
+  def client
+    @client ||= FakeClient.new
+  end
+
+  def inner_app
+    Proc.new do |env|
+      [200, {}, "OK"]
+    end
+  end
+
+  def now
+    @now = Process.clock_gettime(Process::CLOCK_REALTIME)
+  end
+
+  def app
+    @middleware ||= begin
+      app = PrometheusExporter::Middleware.new(inner_app, client: client, instrument: true)
+      def app.request_start
+        1234567891.123
+      end
+      app
+    end
+  end
+
+  def test_converting_apache_request_start
+    now_microsec = '1234567890123456'
+
+    header 'X-Request-Start', "t=#{now_microsec}"
+    get '/'
+    assert last_response.ok?
+
+    refute_nil client.last_send
+    refute_nil client.last_send[:queue_time]
+    assert_in_delta 1, client.last_send[:queue_time], 0.05
+  end
+
+  def test_converting_nginx_request_start
+    now = '1234567890.123'
+    header 'X-Request-Start', "t=#{now}"
+    get '/'
+    assert last_response.ok?
+
+    refute_nil client.last_send
+    refute_nil client.last_send[:queue_time]
+    assert_in_delta 1, client.last_send[:queue_time], 0.05
+  end
+
+  def test_a_header_in_wrong_format
+    header 'X-Request-Start', ""
+    get '/'
+    assert last_response.ok?
+
+    refute_nil client.last_send
+    assert_nil client.last_send[:queue_time]
+  end
+end

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+require 'mini_racer'
+require 'prometheus_exporter/server'
+require 'prometheus_exporter/instrumentation'
+
+class PrometheusWebCollectorTest < Minitest::Test
+  def collector
+    @collector ||= PrometheusExporter::Server::WebCollector.new
+  end
+
+  def test_collecting_metrics_without_specific_timings
+    collector.collect({
+      type: "web",
+      timings: nil,
+      action: 'index',
+      controller: 'home',
+      status: 200
+    })
+
+    metrics = collector.metrics
+
+    assert_equal 5, metrics.size
+  end
+
+  def test_collecting_metrics
+    collector.collect({
+      "type" => "web",
+      "timings" => {
+        "sql" => {
+          duration: 0.5,
+          count: 40
+        },
+        "redis" => {
+          duration: 0.03,
+          count: 4
+        },
+        "queue" => 0.03,
+        "total_duration" => 1.0
+      },
+      "action" => 'index',
+      "controller" => 'home',
+      "status" => 200
+    })
+
+    metrics = collector.metrics
+    assert_equal 5, metrics.size
+  end
+end


### PR DESCRIPTION
This MR adds the possibility to instrument http queuing time when the upstream http server is configured to provide the `X-Request-Start` header.

I tried testing as far as I could, but had no idea on how to properly test the middleware part, as there weren't any existing tests yet... Any hints?