### PR TITLE
Fix metric names and HELP text

### DIFF
--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -27,15 +27,15 @@ module PrometheusExporter::Server
 
         @delayed_job_duration_seconds =
         PrometheusExporter::Metric::Counter.new(
-          "delayed_job_duration_seconds", "Total time spent in delayed jobs")
+          "delayed_job_duration_seconds", "Total time spent in delayed jobs.")
 
         @delayed_job_count =
         PrometheusExporter::Metric::Counter.new(
-          "delayed_jobs_total", "Total number of delayed jobs executed")
+          "delayed_jobs_total", "Total number of delayed jobs executed.")
 
         @delayed_failed_job_count =
         PrometheusExporter::Metric::Counter.new(
-          "delayed_failed_jobs_total", "Total number failed delayed jobs executed")
+          "delayed_failed_jobs_total", "Total number failed delayed jobs executed.")
       end
     end
   end

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -31,11 +31,11 @@ module PrometheusExporter::Server
 
         @delayed_job_count =
         PrometheusExporter::Metric::Counter.new(
-          "delayed_job_count", "Total number of delayed jobs executed")
+          "delayed_jobs_total", "Total number of delayed jobs executed")
 
         @delayed_failed_job_count =
         PrometheusExporter::Metric::Counter.new(
-          "delayed_failed_job_count", "Total number failed delayed jobs executed")
+          "delayed_failed_jobs_total", "Total number failed delayed jobs executed")
       end
     end
   end

--- a/lib/prometheus_exporter/server/process_collector.rb
+++ b/lib/prometheus_exporter/server/process_collector.rb
@@ -5,19 +5,19 @@ module PrometheusExporter::Server
   class ProcessCollector < TypeCollector
     MAX_PROCESS_METRIC_AGE = 60
     PROCESS_GAUGES = {
-      heap_free_slots: "Free ruby heap slots",
-      heap_live_slots: "Used ruby heap slots",
-      v8_heap_size: "Total JavaScript V8 heap size (bytes)",
-      v8_used_heap_size: "Total used JavaScript V8 heap size (bytes)",
-      v8_physical_size: "Physical size consumed by V8 heaps",
-      v8_heap_count: "Number of V8 contexts running",
-      rss: "Total RSS used by process",
+      heap_free_slots: "Free ruby heap slots.",
+      heap_live_slots: "Used ruby heap slots.",
+      v8_heap_size: "Total JavaScript V8 heap size (bytes).",
+      v8_used_heap_size: "Total used JavaScript V8 heap size (bytes).",
+      v8_physical_size: "Physical size consumed by V8 heaps.",
+      v8_heap_count: "Number of V8 contexts running.",
+      rss: "Total RSS used by process.",
     }
 
     PROCESS_COUNTERS = {
-      major_gc_count: "Major GC operations by process",
-      minor_gc_count: "Minor GC operations by process",
-      total_allocated_objects: "Total number of allocateds objects by process",
+      major_gc_ops_total: "Major GC operations by process.",
+      minor_gc_ops_total: "Minor GC operations by process.",
+      allocated_objects_total: "Total number of allocateds objects by process.",
     }
 
     def initialize

--- a/lib/prometheus_exporter/server/sidekiq_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_collector.rb
@@ -27,15 +27,15 @@ module PrometheusExporter::Server
 
         @sidekiq_job_duration_seconds =
         PrometheusExporter::Metric::Counter.new(
-          "sidekiq_job_duration_seconds", "Total time spent in sidekiq jobs")
+          "sidekiq_job_duration_seconds", "Total time spent in sidekiq jobs.")
 
         @sidekiq_job_count =
         PrometheusExporter::Metric::Counter.new(
-          "sidekiq_job_count", "Total number of sidekiq jobs executed")
+          "sidekiq_jobs_total", "Total number of sidekiq jobs executed.")
 
         @sidekiq_failed_job_count =
         PrometheusExporter::Metric::Counter.new(
-          "sidekiq_failed_job_count", "Total number failed sidekiq jobs executed")
+          "sidekiq_failed_jobs_total", "Total number failed sidekiq jobs executed.")
       end
     end
   end

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -24,28 +24,28 @@ module PrometheusExporter::Server
     def ensure_metrics
       unless @http_requests
         @metrics["http_requests"] = @http_requests = PrometheusExporter::Metric::Counter.new(
-          "http_requests",
-          "Total HTTP requests from web app"
+          "http_requests_total",
+          "Total HTTP requests from web app."
         )
 
         @metrics["http_duration_seconds"] = @http_duration_seconds = PrometheusExporter::Metric::Summary.new(
           "http_duration_seconds",
-          "Time spent in HTTP reqs in seconds"
+          "Time spent in HTTP reqs in seconds."
         )
 
         @metrics["http_redis_duration_seconds"] = @http_redis_duration_seconds = PrometheusExporter::Metric::Summary.new(
           "http_redis_duration_seconds",
-          "Time spent in HTTP reqs in redis seconds"
+          "Time spent in HTTP reqs in Redis, in seconds."
         )
 
         @metrics["http_sql_duration_seconds"] = @http_sql_duration_seconds = PrometheusExporter::Metric::Summary.new(
           "http_sql_duration_seconds",
-          "Time spent in HTTP reqs in SQL in seconds"
+          "Time spent in HTTP reqs in SQL in seconds."
         )
 
         @metrics["http_queue_duration_seconds"] = @http_queue_duration_seconds = PrometheusExporter::Metric::Summary.new(
           "http_queue_duration_seconds",
-          "Time spent queueing the request in load balancer in seconds"
+          "Time spent queueing the request in load balancer in seconds."
         )
       end
     end

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -13,11 +13,11 @@ module PrometheusExporter::Server
 
       @verbose = verbose
 
-      @total_metrics = PrometheusExporter::Metric::Counter.new("total_collector_metrics", "total metrics processed by exporter web")
+      @total_metrics = PrometheusExporter::Metric::Counter.new("collector_metrics_total", "Total metrics processed by exporter web.")
 
-      @total_sessions = PrometheusExporter::Metric::Counter.new("total_collector_sessions", "total send_metric sessions processed by exporter web")
+      @total_sessions = PrometheusExporter::Metric::Counter.new("collector_sessions_total", "Total send_metric sessions processed by exporter web.")
 
-      @total_bad_metrics = PrometheusExporter::Metric::Counter.new("total_collector_bad_metrics", "total mis-handled metrics by collector")
+      @total_bad_metrics = PrometheusExporter::Metric::Counter.new("collector_bad_metrics_total", "Total mis-handled metrics by collector.")
 
       @total_metrics.observe(0)
       @total_sessions.observe(0)


### PR DESCRIPTION
By convention, Prometheus counter metrics should have a suffix of `_total`, and all help strings should be proper English sentences.