### PR TITLE
Fix tests broken by metrics naming convention change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: ruby
 rvm:
   - 2.5.0
 before_install: gem install bundler -v 1.16.1
+before_script: sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased
+
+- Follow Prometheus metric [naming conventions](https://prometheus.io/docs/practices/naming/#metric-names)
+
 0.1.15 - 2018-02-19
 
 - Feature: Prefer to use oj if it is loadable

--- a/lib/prometheus_exporter/instrumentation/process.rb
+++ b/lib/prometheus_exporter/instrumentation/process.rb
@@ -51,9 +51,9 @@ module PrometheusExporter::Instrumentation
       stat = GC.stat
       metric[:heap_live_slots] = stat[:heap_live_slots]
       metric[:heap_free_slots] = stat[:heap_free_slots]
-      metric[:major_gc_count] = stat[:major_gc_count]
-      metric[:minor_gc_count] = stat[:minor_gc_count]
-      metric[:total_allocated_objects] = stat[:total_allocated_objects]
+      metric[:major_gc_ops_total] = stat[:major_gc_count]
+      metric[:minor_gc_ops_total] = stat[:minor_gc_count]
+      metric[:allocated_objects_total] = stat[:total_allocated_objects]
     end
 
     def collect_v8_stats(metric)

--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -5,13 +5,13 @@ module PrometheusExporter::Server
   class Collector < CollectorBase
     MAX_PROCESS_METRIC_AGE = 60
     PROCESS_GAUGES = {
-      heap_free_slots: "Free ruby heap slots",
-      heap_live_slots: "Used ruby heap slots",
-      v8_heap_size: "Total JavaScript V8 heap size (bytes)",
-      v8_used_heap_size: "Total used JavaScript V8 heap size (bytes)",
-      v8_physical_size: "Physical size consumed by V8 heaps",
-      v8_heap_count: "Number of V8 contexts running",
-      rss: "Total RSS used by process",
+      heap_free_slots: "Free ruby heap slots.",
+      heap_live_slots: "Used ruby heap slots.",
+      v8_heap_size: "Total JavaScript V8 heap size (bytes).",
+      v8_used_heap_size: "Total used JavaScript V8 heap size (bytes).",
+      v8_physical_size: "Physical size consumed by V8 heaps.",
+      v8_heap_count: "Number of V8 contexts running.",
+      rss: "Total RSS used by process.",
     }
 
     PROCESS_COUNTERS = {

--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -15,9 +15,9 @@ module PrometheusExporter::Server
     }
 
     PROCESS_COUNTERS = {
-      major_gc_count: "Major GC operations by process",
-      minor_gc_count: "Minor GC operations by process",
-      total_allocated_objects: "Total number of allocateds objects by process",
+      major_gc_ops_total: "Major GC operations by process.",
+      minor_gc_ops_total: "Minor GC operations by process.",
+      allocated_objects_total: "Total number of allocated objects by process.",
     }
 
     def initialize(json_serializer: nil)

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -8,13 +8,13 @@ module PrometheusExporter::Server
     def collect(obj)
       ensure_delayed_job_metrics
       @delayed_job_duration_seconds.observe(obj["duration"], job_name: obj["name"])
-      @delayed_job_count.observe(1, job_name: obj["name"])
-      @delayed_failed_job_count.observe(1, job_name: obj["name"]) if !obj["success"]
+      @delayed_jobs_total.observe(1, job_name: obj["name"])
+      @delayed_failed_jobs_total.observe(1, job_name: obj["name"]) if !obj["success"]
     end
 
     def metrics
-      if @delayed_job_count
-        [@delayed_job_duration_seconds, @delayed_job_count, @delayed_failed_job_count]
+      if @delayed_jobs_total
+        [@delayed_job_duration_seconds, @delayed_jobs_total, @delayed_failed_jobs_total]
       else
         []
       end
@@ -23,17 +23,17 @@ module PrometheusExporter::Server
     protected
 
     def ensure_delayed_job_metrics
-      if !@delayed_job_count
+      if !@delayed_jobs_total
 
         @delayed_job_duration_seconds =
         PrometheusExporter::Metric::Counter.new(
           "delayed_job_duration_seconds", "Total time spent in delayed jobs.")
 
-        @delayed_job_count =
+        @delayed_jobs_total =
         PrometheusExporter::Metric::Counter.new(
           "delayed_jobs_total", "Total number of delayed jobs executed.")
 
-        @delayed_failed_job_count =
+        @delayed_failed_jobs_total =
         PrometheusExporter::Metric::Counter.new(
           "delayed_failed_jobs_total", "Total number failed delayed jobs executed.")
       end

--- a/lib/prometheus_exporter/server/process_collector.rb
+++ b/lib/prometheus_exporter/server/process_collector.rb
@@ -17,7 +17,7 @@ module PrometheusExporter::Server
     PROCESS_COUNTERS = {
       major_gc_ops_total: "Major GC operations by process.",
       minor_gc_ops_total: "Minor GC operations by process.",
-      allocated_objects_total: "Total number of allocateds objects by process.",
+      allocated_objects_total: "Total number of allocated objects by process.",
     }
 
     def initialize

--- a/lib/prometheus_exporter/server/sidekiq_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_collector.rb
@@ -8,13 +8,13 @@ module PrometheusExporter::Server
     def collect(obj)
       ensure_sidekiq_metrics
       @sidekiq_job_duration_seconds.observe(obj["duration"], job_name: obj["name"])
-      @sidekiq_job_count.observe(1, job_name: obj["name"])
-      @sidekiq_failed_job_count.observe(1, job_name: obj["name"]) if !obj["success"]
+      @sidekiq_jobs_total.observe(1, job_name: obj["name"])
+      @sidekiq_failed_jobs_total.observe(1, job_name: obj["name"]) if !obj["success"]
     end
 
     def metrics
-      if @sidekiq_job_count
-        [@sidekiq_job_duration_seconds, @sidekiq_job_count, @sidekiq_failed_job_count]
+      if @sidekiq_jobs_total
+        [@sidekiq_job_duration_seconds, @sidekiq_jobs_total, @sidekiq_failed_jobs_total]
       else
         []
       end
@@ -23,17 +23,17 @@ module PrometheusExporter::Server
     protected
 
     def ensure_sidekiq_metrics
-      if !@sidekiq_job_count
+      if !@sidekiq_jobs_total
 
         @sidekiq_job_duration_seconds =
         PrometheusExporter::Metric::Counter.new(
           "sidekiq_job_duration_seconds", "Total time spent in sidekiq jobs.")
 
-        @sidekiq_job_count =
+        @sidekiq_jobs_total =
         PrometheusExporter::Metric::Counter.new(
           "sidekiq_jobs_total", "Total number of sidekiq jobs executed.")
 
-        @sidekiq_failed_job_count =
+        @sidekiq_failed_jobs_total =
         PrometheusExporter::Metric::Counter.new(
           "sidekiq_failed_jobs_total", "Total number failed sidekiq jobs executed.")
       end

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -22,8 +22,8 @@ module PrometheusExporter::Server
     protected
 
     def ensure_metrics
-      unless @http_requests
-        @metrics["http_requests_total"] = @http_requests = PrometheusExporter::Metric::Counter.new(
+      unless @http_requests_total
+        @metrics["http_requests_total"] = @http_requests_total = PrometheusExporter::Metric::Counter.new(
           "http_requests_total",
           "Total HTTP requests from web app."
         )
@@ -57,7 +57,7 @@ module PrometheusExporter::Server
         action: obj["action"] || "other"
       }
 
-      @http_requests.observe(1, labels.merge(status: obj["status"]))
+      @http_requests_total.observe(1, labels.merge(status: obj["status"]))
 
       if timings = obj["timings"]
         @http_duration_seconds.observe(timings["total_duration"], labels)

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -23,7 +23,7 @@ module PrometheusExporter::Server
 
     def ensure_metrics
       unless @http_requests
-        @metrics["http_requests"] = @http_requests = PrometheusExporter::Metric::Counter.new(
+        @metrics["http_requests_total"] = @http_requests = PrometheusExporter::Metric::Counter.new(
           "http_requests_total",
           "Total HTTP requests from web app."
         )

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -54,9 +54,9 @@ class PrometheusCollectorTest < Minitest::Test
 
     result = collector.prometheus_metrics_text
 
-    assert(result.include?("sidekiq_failed_job_count{job_name=\"FalseClass\"} 1"), "has failed job")
+    assert(result.include?("sidekiq_failed_jobs_total{job_name=\"FalseClass\"} 1"), "has failed job")
 
-    assert(result.include?("sidekiq_job_count{job_name=\"String\"} 1"), "has working job")
+    assert(result.include?("sidekiq_jobs_total{job_name=\"String\"} 1"), "has working job")
     assert(result.include?("sidekiq_job_duration_seconds"), "has duration")
   end
 
@@ -76,7 +76,7 @@ class PrometheusCollectorTest < Minitest::Test
 
     v8_str = "v8_heap_count{pid=\"#{collected[:pid]}\",type=\"web\"} #{collected[:v8_heap_count]}"
     assert(text.include?(v8_str), "must include v8 metric")
-    assert(text.include?("minor_gc_count"), "must include counters")
+    assert(text.include?("minor_gc_ops_total"), "must include counters")
   end
 
   def test_it_can_collect_delayed_job_metrics
@@ -104,8 +104,8 @@ class PrometheusCollectorTest < Minitest::Test
 
     result = collector.prometheus_metrics_text
 
-    assert(result.include?("delayed_failed_job_count{job_name=\"Object\"} 1"), "has failed job")
-    assert(result.include?("delayed_job_count{job_name=\"Class\"} 1"), "has working job")
+    assert(result.include?("delayed_failed_jobs_total{job_name=\"Object\"} 1"), "has failed job")
+    assert(result.include?("delayed_jobs_total{job_name=\"Class\"} 1"), "has working job")
     assert(result.include?("delayed_job_duration_seconds"), "has duration")
     job.verify
     failed_job.verify


### PR DESCRIPTION
This PR fixes a few issues introduced by #12 (including the failing tests mentioned in #14.) I've also added a `CHANGELOG` entry and renamed variables to reflect the new metrics names.