### PR TITLE
Add support to configure timeout

### DIFF
--- a/bin/prometheus_exporter
+++ b/bin/prometheus_exporter
@@ -18,6 +18,12 @@ def run
            "Port exporter should listen on (default: #{PrometheusExporter::DEFAULT_PORT})") do |o|
       options[:port] = o.to_i
     end
+    opt.on('-t',
+           '--timeout INTEGER',
+           Integer,
+           "Timeout in seconds for metrics endpoint (default: #{PrometheusExporter::DEFAULT_TIMEOUT})") do |o|
+      options[:timeout] = o.to_i
+    end
     opt.on('--prefix METRIC_PREFIX', String, "Prefix to apply to all metrics (default: #{PrometheusExporter::DEFAULT_PREFIX})") do |o|
       options[:prefix] = o.to_s
     end

--- a/lib/prometheus_exporter.rb
+++ b/lib/prometheus_exporter.rb
@@ -6,6 +6,7 @@ module PrometheusExporter
   # per: https://github.com/prometheus/prometheus/wiki/Default-port-allocations
   DEFAULT_PORT = 9394
   DEFAULT_PREFIX = 'ruby_'
+  DEFAULT_TIMEOUT = 2
 
   class OjCompat
     def self.parse(obj)

--- a/lib/prometheus_exporter/server/runner.rb
+++ b/lib/prometheus_exporter/server/runner.rb
@@ -20,7 +20,7 @@ module PrometheusExporter::Server
         raise WrongInheritance, 'Collector class must be inherited from PrometheusExporter::Server::CollectorBase'
       end
 
-      server = server_class.new port: port, collector: collector, verbose: verbose
+      server = server_class.new port: port, collector: collector, timeout: timeout, verbose: verbose
       server.start
     end
 
@@ -54,6 +54,14 @@ module PrometheusExporter::Server
 
     def type_collectors
       @type_collectors || []
+    end
+
+    def timeout=(timeout)
+      @timeout = timeout
+    end
+
+    def timeout
+      @timeout || PrometheusExporter::DEFAULT_TIMEOUT
     end
 
     def verbose=(verbose)

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -9,7 +9,7 @@ module PrometheusExporter::Server
   class WebServer
     attr_reader :collector
 
-    def initialize(port: , collector: nil, verbose: false)
+    def initialize(port: , collector: nil, timeout: PrometheusExporter::DEFAULT_TIMEOUT, verbose: false)
 
       @verbose = verbose
 
@@ -44,6 +44,7 @@ module PrometheusExporter::Server
 
       @collector = collector || Collector.new
       @port = port
+      @timeout = timeout
 
       @server.mount_proc '/' do |req, res|
         res['ContentType'] = 'text/plain; charset=utf-8'
@@ -113,7 +114,7 @@ module PrometheusExporter::Server
     def metrics
       metric_text = nil
       begin
-        Timeout::timeout(2) do
+        Timeout::timeout(@timeout) do
           metric_text = @collector.prometheus_metrics_text
         end
       rescue Timeout::Error

--- a/test/server/runner_test.rb
+++ b/test/server/runner_test.rb
@@ -44,6 +44,7 @@ class PrometheusRunnerTest < Minitest::Test
 
     assert_equal(runner.prefix, 'ruby_')
     assert_equal(runner.port, 9394)
+    assert_equal(runner.timeout, 2)
     assert_equal(runner.collector_class, PrometheusExporter::Server::Collector)
     assert_equal(runner.type_collectors, [])
     assert_equal(runner.verbose, false)
@@ -53,6 +54,7 @@ class PrometheusRunnerTest < Minitest::Test
     runner = PrometheusExporter::Server::Runner.new(
       prefix: 'new_',
       port: 1234,
+      timeout: 1,
       collector_class: CollectorMock,
       type_collectors: [TypeCollectorMock],
       verbose: true
@@ -60,6 +62,7 @@ class PrometheusRunnerTest < Minitest::Test
 
     assert_equal(runner.prefix, 'new_')
     assert_equal(runner.port, 1234)
+    assert_equal(runner.timeout, 1)
     assert_equal(runner.collector_class, CollectorMock)
     assert_equal(runner.type_collectors, [TypeCollectorMock])
     assert_equal(runner.verbose, true)
@@ -72,6 +75,7 @@ class PrometheusRunnerTest < Minitest::Test
     assert_equal(result, true)
     assert_equal(PrometheusExporter::Metric::Base.default_prefix, 'ruby_')
     assert_equal(runner.port, 9394)
+    assert_equal(runner.timeout, 2)
     assert_equal(runner.verbose, false)
     assert_instance_of(PrometheusExporter::Server::Collector, runner.collector)
   end


### PR DESCRIPTION
By default the timeout is 2 which is reasonable, but I ran into having an
endpoint that was slightly slower than 2 seconds sometimes. It was quite a
hassle to monkey patch the whole metrics endpoint to change this timeout, so I
think it would make sense to have it configurable.

It might make sense to add tests of the timeout in the web_server tests, but since there doesn't seem to be any currently I didn't bother. Is that something that you would like?

Thanks for a truly useful gem, best regards.