### PR TITLE
Allow empty prefix for metrics running multi process mode

### DIFF
--- a/bin/prometheus_exporter
+++ b/bin/prometheus_exporter
@@ -24,7 +24,7 @@ def run
            "Timeout in seconds for metrics endpoint (default: #{PrometheusExporter::DEFAULT_TIMEOUT})") do |o|
       options[:timeout] = o.to_i
     end
-    opt.on('--prefix METRIC_PREFIX', String, "Prefix to apply to all metrics (default: #{PrometheusExporter::DEFAULT_PREFIX})") do |o|
+    opt.on('--prefix METRIC_PREFIX', "Prefix to apply to all metrics (default: #{PrometheusExporter::DEFAULT_PREFIX})") do |o|
       options[:prefix] = o.to_s
     end
     opt.on('-c', '--collector FILE', String, "(optional) Custom collector to run") do |o|


### PR DESCRIPTION
As mentioned in the documentation:
https://ruby-doc.org/stdlib-2.5.1/libdoc/optparse/rdoc/OptionParser.html#class-OptionParser-label-Type+Coercion

`String – Any non-empty string`

If you would like to skip the prefix by just providing `--prefix=''` it is not
possible as long as the Type Coercion String is specified.

Is there any other benefits to having the String coercion or would it be okay to omit it as proposed in this PR.