### PR TITLE
Add possibility to set custom_labels in multi-process mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-sudo: false
+sudo: required
 language: ruby
+dist: trusty
 rvm:
   - 2.5.0
 before_install: gem install bundler -v 1.16.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.3.2
+
+- Feature: Add posibility to set custom_labels on multi process mode
+
 0.3.1
 
 - Allow runner to accept a --timeout var

--- a/README.md
+++ b/README.md
@@ -361,6 +361,26 @@ ruby_web_requests{hostname="app-server-01",route="test/route"} 1
 ruby_web_requests{hostname="app-server-01"} 1
 ```
 
+### Client default labels
+
+You can specify a default label for the instrumentation metrics sent by an specific client, for example:
+
+```ruby
+# Specify on intializing PrometheusExporter::Client
+PrometheusExporter::Client.new(custom_labels: { hostname: 'app-server-01', app_name: 'app-01' })
+
+# Specify on an instance of PrometheusExporter::Client
+client = PrometheusExporter::Client.new
+client.custom_labels = { hostname: 'app-server-01', app_name: 'app-01' }
+```
+
+Will result in:
+
+```
+http_requests_total{controller="home","action"="index",service="app-server-01",app_name="app-01"} 2
+http_requests_total{service="app-server-01",app_name="app-01"} 1
+```
+
 ## Transport concerns
 
 Prometheus Exporter handles transport using a simple HTTP protocol. In multi process mode we avoid needing a large number of HTTP request by using chunked encoding to send metrics. This means that a single HTTP channel can deliver 100s or even 1000s of metrics over a single HTTP session to the `/send-metrics` endpoint. All calls to `send` and `send_json` on the PrometheusExporter::Client class are **non-blocking** and batched.

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -35,7 +35,7 @@ class PrometheusExporter::Client
   MAX_SOCKET_AGE = 25
   MAX_QUEUE_SIZE = 10_000
 
-  def initialize(host: 'localhost', port: PrometheusExporter::DEFAULT_PORT, max_queue_size: nil, thread_sleep: 0.5, json_serializer: nil, custom_labels: {})
+  def initialize(host: 'localhost', port: PrometheusExporter::DEFAULT_PORT, max_queue_size: nil, thread_sleep: 0.5, json_serializer: nil, custom_labels: nil)
     @metrics = []
 
     @queue = Queue.new
@@ -72,7 +72,7 @@ class PrometheusExporter::Client
   end
 
   def send_json(obj)
-    payload = obj.merge(custom_labels: @custom_labels)
+    payload = @custom_labels.nil? ? obj : obj.merge(custom_labels: @custom_labels)
     send(@json_serializer.dump(payload))
   end
 

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -35,7 +35,7 @@ class PrometheusExporter::Client
   MAX_SOCKET_AGE = 25
   MAX_QUEUE_SIZE = 10_000
 
-  def initialize(host: 'localhost', port: PrometheusExporter::DEFAULT_PORT, max_queue_size: nil, thread_sleep: 0.5, json_serializer: nil)
+  def initialize(host: 'localhost', port: PrometheusExporter::DEFAULT_PORT, max_queue_size: nil, thread_sleep: 0.5, json_serializer: nil, custom_labels: {})
     @metrics = []
 
     @queue = Queue.new
@@ -57,6 +57,12 @@ class PrometheusExporter::Client
     @thread_sleep = thread_sleep
 
     @json_serializer = json_serializer == :oj ? PrometheusExporter::OjCompat : JSON
+
+    @custom_labels = custom_labels
+  end
+
+  def custom_labels=(custom_labels)
+    @custom_labels = custom_labels
   end
 
   def register(type, name, help)
@@ -66,7 +72,8 @@ class PrometheusExporter::Client
   end
 
   def send_json(obj)
-    send(@json_serializer.dump(obj))
+    payload = obj.merge(custom_labels: @custom_labels)
+    send(@json_serializer.dump(payload))
   end
 
   def send(str)

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -6,10 +6,13 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
+      custom_labels = obj.fetch('custom_labels', {})
+      labels = { job_name: obj['name'] }.merge(custom_labels)
+
       ensure_delayed_job_metrics
-      @delayed_job_duration_seconds.observe(obj["duration"], job_name: obj["name"])
-      @delayed_jobs_total.observe(1, job_name: obj["name"])
-      @delayed_failed_jobs_total.observe(1, job_name: obj["name"]) if !obj["success"]
+      @delayed_job_duration_seconds.observe(obj["duration"], labels)
+      @delayed_jobs_total.observe(1, labels)
+      @delayed_failed_jobs_total.observe(1, labels) if !obj["success"]
     end
 
     def metrics

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -6,8 +6,9 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
-      custom_labels = obj.fetch('custom_labels', {})
-      labels = { job_name: obj['name'] }.merge(custom_labels)
+      default_labels = { job_name: obj['name'] }
+      custom_labels = obj['custom_labels']
+      labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
 
       ensure_delayed_job_metrics
       @delayed_job_duration_seconds.observe(obj["duration"], labels)

--- a/lib/prometheus_exporter/server/sidekiq_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_collector.rb
@@ -6,8 +6,9 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
-      custom_labels = obj.fetch('custom_labels', {})
-      labels = { job_name: obj['name'] }.merge(custom_labels)
+      default_labels = { job_name: obj['name'] }
+      custom_labels = obj['custom_labels']
+      labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
 
       ensure_sidekiq_metrics
       @sidekiq_job_duration_seconds.observe(obj["duration"], labels)

--- a/lib/prometheus_exporter/server/sidekiq_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_collector.rb
@@ -6,10 +6,13 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
+      custom_labels = obj.fetch('custom_labels', {})
+      labels = { job_name: obj['name'] }.merge(custom_labels)
+
       ensure_sidekiq_metrics
-      @sidekiq_job_duration_seconds.observe(obj["duration"], job_name: obj["name"])
-      @sidekiq_jobs_total.observe(1, job_name: obj["name"])
-      @sidekiq_failed_jobs_total.observe(1, job_name: obj["name"]) if !obj["success"]
+      @sidekiq_job_duration_seconds.observe(obj["duration"], labels)
+      @sidekiq_jobs_total.observe(1, labels)
+      @sidekiq_failed_jobs_total.observe(1, labels) if !obj["success"]
     end
 
     def metrics

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -51,11 +51,12 @@ module PrometheusExporter::Server
     end
 
     def observe(obj)
-      custom_labels = obj.fetch('custom_labels', {})
-      labels = {
-        controller: obj["controller"] || "other",
-        action: obj["action"] || "other"
-      }.merge(custom_labels)
+      default_labels = {
+        controller: obj['controller'] || 'other',
+        action: obj['action'] || 'other'
+      }
+      custom_labels = obj['custom_labels']
+      labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
 
       @http_requests_total.observe(1, labels.merge(status: obj["status"]))
 

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -51,11 +51,11 @@ module PrometheusExporter::Server
     end
 
     def observe(obj)
-
+      custom_labels = obj.fetch('custom_labels', {})
       labels = {
         controller: obj["controller"] || "other",
         action: obj["action"] || "other"
-      }
+      }.merge(custom_labels)
 
       @http_requests_total.observe(1, labels.merge(status: obj["status"]))
 

--- a/lib/prometheus_exporter/version.rb
+++ b/lib/prometheus_exporter/version.rb
@@ -1,3 +1,3 @@
 module PrometheusExporter
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -10,12 +10,14 @@ class PrometheusCollectorTest < Minitest::Test
   end
 
   class PipedClient
-    def initialize(collector)
+    def initialize(collector, custom_labels: {})
       @collector = collector
+      @custom_labels = custom_labels
     end
 
     def send_json(obj)
-      @collector.process(obj.to_json)
+      payload = obj.merge(custom_labels: @custom_labels).to_json
+      @collector.process(payload)
     end
   end
 
@@ -58,6 +60,30 @@ class PrometheusCollectorTest < Minitest::Test
 
     assert(result.include?("sidekiq_jobs_total{job_name=\"String\"} 1"), "has working job")
     assert(result.include?("sidekiq_job_duration_seconds"), "has duration")
+  end
+
+  def test_it_can_collect_sidekiq_metrics_with_custom_labels
+    collector = PrometheusExporter::Server::Collector.new
+    client = PipedClient.new(collector, custom_labels: { service: 'service1' })
+
+    instrument = PrometheusExporter::Instrumentation::Sidekiq.new(client: client)
+
+    instrument.call("hello", nil, "default") do
+      # nothing
+    end
+
+    begin
+      instrument.call(false, nil, "default") do
+        boom
+      end
+    rescue
+    end
+
+    result = collector.prometheus_metrics_text
+
+    assert(result.include?('sidekiq_failed_jobs_total{job_name="FalseClass",service="service1"} 1'), "has failed job")
+    assert(result.include?('sidekiq_jobs_total{job_name="String",service="service1"} 1'), "has working job")
+    assert(result.include?('sidekiq_job_duration_seconds{job_name="FalseClass",service="service1"}'), "has duration")
   end
 
   def test_it_can_collect_process_metrics
@@ -110,4 +136,37 @@ class PrometheusCollectorTest < Minitest::Test
     job.verify
     failed_job.verify
   end
+
+  def test_it_can_collect_delayed_job_metrics_with_custom_labels
+    collector = PrometheusExporter::Server::Collector.new
+    client = PipedClient.new(collector, custom_labels: { service: 'service1' })
+
+    instrument = PrometheusExporter::Instrumentation::DelayedJob.new(client: client)
+
+    job = Minitest::Mock.new
+    job.expect(:handler, "job_class: Class")
+
+    instrument.call(job, nil, "default") do
+      # nothing
+    end
+
+    failed_job = Minitest::Mock.new
+    failed_job.expect(:handler, "job_class: Object")
+
+    begin
+      instrument.call(failed_job, nil, "default") do
+        boom
+      end
+    rescue
+    end
+
+    result = collector.prometheus_metrics_text
+
+    assert(result.include?('delayed_failed_jobs_total{job_name="Object",service="service1"} 1'), "has failed job")
+    assert(result.include?('delayed_jobs_total{job_name="Class",service="service1"} 1'), "has working job")
+    assert(result.include?('delayed_job_duration_seconds{job_name="Class",service="service1"}'), "has duration")
+    job.verify
+    failed_job.verify
+  end
+
 end

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -10,7 +10,7 @@ class PrometheusCollectorTest < Minitest::Test
   end
 
   class PipedClient
-    def initialize(collector, custom_labels: {})
+    def initialize(collector, custom_labels: nil)
       @collector = collector
       @custom_labels = custom_labels
     end

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -45,4 +45,22 @@ class PrometheusWebCollectorTest < Minitest::Test
     metrics = collector.metrics
     assert_equal 5, metrics.size
   end
+
+  def test_collecting_metrics_with_custom_labels
+    collector.collect({
+      'type' => 'web',
+      'timings' => nil,
+      'action' => 'index',
+      'controller' => 'home',
+      'status' => 200,
+      'custom_labels' => {
+        'service' => 'service1'
+      }
+    })
+
+    metrics = collector.metrics
+
+    assert_equal 5, metrics.size
+    assert(metrics.first.metric_text.include?('http_requests_total{controller="home",action="index",service="service1",status="200"}'))
+  end
 end


### PR DESCRIPTION
Recently I had the need to use this feature set default labels on a multi-process setup as I wanted to have:
1 stand-alone prometheus_exporter server and many different projects reporting to that one server, while still be able to identify which metrics belong to which service

With this changes it would be possible to do the following on the different projects:
```
PrometheusExporter::Client.new(custom_labels: { service: SERVICE_NAME })
```

and on the server's `/metrics` get the following: 
```
http_requests_total{controller="home",action="index",service="CoolService",status="200"} 5
http_requests_total{controller="home",action="index",service="NotCoolService",status="200"} 2
```