### PR TITLE
Added more useful metrics to be collected for delayed jobs

### DIFF
--- a/lib/prometheus_exporter/instrumentation/delayed_job.rb
+++ b/lib/prometheus_exporter/instrumentation/delayed_job.rb
@@ -26,6 +26,7 @@ module PrometheusExporter::Instrumentation
     def call(job, *args, &block)
       success = false
       start = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      attempts = job.attempts + 1 # Increment because we're adding the current attempt
       result = block.call(job, *args)
       success = true
       result
@@ -36,7 +37,8 @@ module PrometheusExporter::Instrumentation
         type: "delayed_job",
         name: job.handler.to_s.match(JOB_CLASS_REGEXP).to_a[1].to_s,
         success: success,
-        duration: duration
+        duration: duration,
+        attempts: attempts
       )
     end
   end

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -14,7 +14,7 @@ module PrometheusExporter::Server
       @delayed_job_duration_seconds.observe(obj["duration"], labels)
       @delayed_jobs_total.observe(1, labels)
       @delayed_failed_jobs_total.observe(1, labels) if !obj["success"]
-      @delayed_job_max_attempts_reached.observe(1) if obj["attempts"] >= (Delayed::Worker.max_attempts)
+      @delayed_job_max_attempts_reached.observe(1) if obj["attempts"] >= obj["max_attempts"]
       @delayed_job_duration_summary.observe(obj["duration"])
       @delayed_job_duration_summary.observe(obj["duration"], status: "success") if obj["success"]
       @delayed_job_duration_summary.observe(obj["duration"], status: "failed")  if !obj["success"]

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -14,11 +14,17 @@ module PrometheusExporter::Server
       @delayed_job_duration_seconds.observe(obj["duration"], labels)
       @delayed_jobs_total.observe(1, labels)
       @delayed_failed_jobs_total.observe(1, labels) if !obj["success"]
+      @delayed_job_max_attempts_reached.observe(1) if obj["attempts"] >= (Delayed::Worker.max_attempts)
+      @delayed_job_duration_summary.observe(obj["duration"])
+      @delayed_job_duration_summary.observe(obj["duration"], status: "success") if obj["success"]
+      @delayed_job_duration_summary.observe(obj["duration"], status: "failed")  if !obj["success"]
+      @delayed_job_attempts_summary.observe(obj["attempts"]) if obj["success"]
     end
 
     def metrics
       if @delayed_jobs_total
-        [@delayed_job_duration_seconds, @delayed_jobs_total, @delayed_failed_jobs_total]
+        [@delayed_job_duration_seconds, @delayed_jobs_total, @delayed_failed_jobs_total, @delayed_job_max_attempts_reached,
+         @delayed_job_duration_summary, @delayed_job_attempts_summary]
       else
         []
       end
@@ -40,6 +46,18 @@ module PrometheusExporter::Server
         @delayed_failed_jobs_total =
         PrometheusExporter::Metric::Counter.new(
           "delayed_failed_jobs_total", "Total number failed delayed jobs executed.")
+
+        @delayed_job_max_attempts_reached =
+            PrometheusExporter::Metric::Counter.new(
+                "delayed_job_max_attempts_reached", "Total number of delayed jobs that reached max attempts.")
+
+        @delayed_job_duration_summary =
+            PrometheusExporter::Metric::Summary.new("delayed_job_duration_summary",
+                                                    "Summary of the time it takes for a job to execute.")
+
+        @delayed_job_attempts_summary =
+            PrometheusExporter::Metric::Summary.new("delayed_job_attempts_summary",
+                                                    "Summary of the amount of attempts it takes delayed jobs to succeed.")
       end
     end
   end

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -14,17 +14,17 @@ module PrometheusExporter::Server
       @delayed_job_duration_seconds.observe(obj["duration"], labels)
       @delayed_jobs_total.observe(1, labels)
       @delayed_failed_jobs_total.observe(1, labels) if !obj["success"]
-      @delayed_job_max_attempts_reached.observe(1) if obj["attempts"] >= obj["max_attempts"]
-      @delayed_job_duration_summary.observe(obj["duration"])
-      @delayed_job_duration_summary.observe(obj["duration"], status: "success") if obj["success"]
-      @delayed_job_duration_summary.observe(obj["duration"], status: "failed")  if !obj["success"]
+      @delayed_jobs_max_attempts_reached_total.observe(1) if obj["attempts"] >= obj["max_attempts"]
+      @delayed_job_duration_seconds_summary.observe(obj["duration"])
+      @delayed_job_duration_seconds_summary.observe(obj["duration"], status: "success") if obj["success"]
+      @delayed_job_duration_seconds_summary.observe(obj["duration"], status: "failed")  if !obj["success"]
       @delayed_job_attempts_summary.observe(obj["attempts"]) if obj["success"]
     end
 
     def metrics
       if @delayed_jobs_total
-        [@delayed_job_duration_seconds, @delayed_jobs_total, @delayed_failed_jobs_total, @delayed_job_max_attempts_reached,
-         @delayed_job_duration_summary, @delayed_job_attempts_summary]
+        [@delayed_job_duration_seconds, @delayed_jobs_total, @delayed_failed_jobs_total,
+         @delayed_jobs_max_attempts_reached_total, @delayed_job_duration_seconds_summary, @delayed_job_attempts_summary]
       else
         []
       end
@@ -47,13 +47,13 @@ module PrometheusExporter::Server
         PrometheusExporter::Metric::Counter.new(
           "delayed_failed_jobs_total", "Total number failed delayed jobs executed.")
 
-        @delayed_job_max_attempts_reached =
+        @delayed_jobs_max_attempts_reached_total =
             PrometheusExporter::Metric::Counter.new(
-                "delayed_job_max_attempts_reached", "Total number of delayed jobs that reached max attempts.")
+                "delayed_jobs_max_attempts_reached_total", "Total number of delayed jobs that reached max attempts.")
 
-        @delayed_job_duration_summary =
-            PrometheusExporter::Metric::Summary.new("delayed_job_duration_summary",
-                                                    "Summary of the time it takes for a job to execute.")
+        @delayed_job_duration_seconds_summary =
+            PrometheusExporter::Metric::Summary.new("delayed_job_duration_seconds_summary",
+                                                    "Summary of the time it takes jobs to execute.")
 
         @delayed_job_attempts_summary =
             PrometheusExporter::Metric::Summary.new("delayed_job_attempts_summary",

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -113,6 +113,7 @@ class PrometheusCollectorTest < Minitest::Test
 
     job = Minitest::Mock.new
     job.expect(:handler, "job_class: Class")
+    job.expect(:attempts, 0)
 
     instrument.call(job, nil, "default") do
       # nothing
@@ -145,6 +146,7 @@ class PrometheusCollectorTest < Minitest::Test
 
     job = Minitest::Mock.new
     job.expect(:handler, "job_class: Class")
+    job.expect(:attempts, 0)
 
     instrument.call(job, nil, "default") do
       # nothing

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -115,15 +115,16 @@ class PrometheusCollectorTest < Minitest::Test
     job.expect(:handler, "job_class: Class")
     job.expect(:attempts, 0)
 
-    instrument.call(job, nil, "default") do
+    instrument.call(job,20, nil, "default") do
       # nothing
     end
 
     failed_job = Minitest::Mock.new
     failed_job.expect(:handler, "job_class: Object")
+    failed_job.expect(:attempts, 1)
 
     begin
-      instrument.call(failed_job, nil, "default") do
+      instrument.call(failed_job, 25, nil, "default") do
         boom
       end
     rescue
@@ -148,15 +149,17 @@ class PrometheusCollectorTest < Minitest::Test
     job.expect(:handler, "job_class: Class")
     job.expect(:attempts, 0)
 
-    instrument.call(job, nil, "default") do
+    instrument.call(job, 25,nil, "default") do
       # nothing
     end
 
     failed_job = Minitest::Mock.new
     failed_job.expect(:handler, "job_class: Object")
+    failed_job.expect(:attempts, 1)
+
 
     begin
-      instrument.call(failed_job, nil, "default") do
+      instrument.call(failed_job, 25, nil, "default") do
         boom
       end
     rescue


### PR DESCRIPTION
I really like this library and the build in plugin for delayed job metrics, but I felt that the actual metrics that were being collected were a bit sparse. I've added a couple more metrics that, in my opinion, collect useful and necessary information about delayed jobs. I've added a summary of the duration it takes jobs to run (with a separation of failed and successful executed jobs), a summary of the amount of attempts it takes before jobs succeed and a counter that tells you how many jobs actually reached their max attempts.

I feel like these additions can help users monitor their delayed jobs better and let's them, for example, set alerts for when the amount of attempts needed for jobs to succeed significantly grows. 