### PR TITLE
Feature/grape instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,12 @@ thing1 122
 thing2 12
 ```
 
+### GraphQL support
+
+GraphQL execution metrics are [supported](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/queries/tracing.md#prometheus) and can be collected via the GraphQL
+collector, included in [graphql-ruby](https://github.com/rmosolgo/graphql-ruby)
+
+
 ### Metrics default prefix / labels
 
 _This only works in single process mode_

--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -34,9 +34,17 @@ class PrometheusExporter::Middleware
     status = (result && result[0]) || -1
     params = env["action_dispatch.request.parameters"]
     action, controller = nil
+    grape = env["api.endpoint"]
+    grape_module, grape_path = nil
+
     if params
       action = params["action"]
       controller = params["controller"]
+    end
+
+    if grape
+      grape_module = grape.options[:for]
+      grape_path = grape.options[:path].try(:first)
     end
 
     @client.send_json(
@@ -45,6 +53,8 @@ class PrometheusExporter::Middleware
       queue_time: queue_time,
       action: action,
       controller: controller,
+      grape_module: grape_module,
+      grape_path: grape_path,
       status: status
     )
   end

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -53,7 +53,9 @@ module PrometheusExporter::Server
     def observe(obj)
       default_labels = {
         controller: obj['controller'] || 'other',
-        action: obj['action'] || 'other'
+        action: obj['action'] || 'other',
+        grape_module: obj['grape_module'] || 'other',
+        grape_path: obj['grape_path'] || 'other'
       }
       custom_labels = obj['custom_labels']
       labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)


### PR DESCRIPTION
This PR adds labels to [Grape](https://github.com/ruby-grape/grape) API endpoints. @SamSaffron let me know if you think this is appropriate to add in here or if its outside the scope of this gem and should be in its own module somewhere