### PR TITLE
allow gauges to increment and decrement. w/ burnettk

### DIFF
--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -21,7 +21,7 @@ class PrometheusExporter::Client
         keys: keys,
         value: value
       }
-      values.merge!(prometheus_exporter_action: prometheus_exporter_action) if prometheus_exporter_action
+      values[:prometheus_exporter_action] = prometheus_exporter_action if prometheus_exporter_action
       values
     end
 

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -13,15 +13,28 @@ class PrometheusExporter::Client
       @type = type
     end
 
-    def observe(value = 1, keys = nil)
-      @client.send_json(
+    def standard_values(value, keys)
+      {
         type: @type,
         help: @help,
         name: @name,
         keys: keys,
         value: value
-      )
+      }
     end
+
+    def observe(value = 1, keys = nil)
+      @client.send_json(standard_values(value, keys))
+    end
+
+    def increment(value = 1, keys = nil)
+      @client.send_json(standard_values(value, keys).merge(action: :increment))
+    end
+
+    def decrement(value = 1, keys = nil)
+      @client.send_json(standard_values(value, keys).merge(action: :decrement))
+    end
+
   end
 
   def self.default

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -13,14 +13,16 @@ class PrometheusExporter::Client
       @type = type
     end
 
-    def standard_values(value, keys)
-      {
+    def standard_values(value, keys, action = nil)
+      values = {
         type: @type,
         help: @help,
         name: @name,
         keys: keys,
         value: value
       }
+      values.merge!(action: action) if action
+      values
     end
 
     def observe(value = 1, keys = nil)
@@ -28,11 +30,11 @@ class PrometheusExporter::Client
     end
 
     def increment(value = 1, keys = nil)
-      @client.send_json(standard_values(value, keys).merge(action: :increment))
+      @client.send_json(standard_values(value, keys, :increment))
     end
 
     def decrement(value = 1, keys = nil)
-      @client.send_json(standard_values(value, keys).merge(action: :decrement))
+      @client.send_json(standard_values(value, keys, :decrement))
     end
 
   end

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -13,7 +13,7 @@ class PrometheusExporter::Client
       @type = type
     end
 
-    def standard_values(value, keys, action = nil)
+    def standard_values(value, keys, prometheus_exporter_action = nil)
       values = {
         type: @type,
         help: @help,
@@ -21,7 +21,7 @@ class PrometheusExporter::Client
         keys: keys,
         value: value
       }
-      values.merge!(action: action) if action
+      values.merge!(prometheus_exporter_action: prometheus_exporter_action) if prometheus_exporter_action
       values
     end
 

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -29,11 +29,11 @@ class PrometheusExporter::Client
       @client.send_json(standard_values(value, keys))
     end
 
-    def increment(value = 1, keys = nil)
+    def increment(keys = nil, value = 1)
       @client.send_json(standard_values(value, keys, :increment))
     end
 
-    def decrement(value = 1, keys = nil)
+    def decrement(keys = nil, value = 1)
       @client.send_json(standard_values(value, keys, :decrement))
     end
 

--- a/lib/prometheus_exporter/metric/gauge.rb
+++ b/lib/prometheus_exporter/metric/gauge.rb
@@ -22,5 +22,15 @@ module PrometheusExporter::Metric
     def observe(value, labels = {})
       @data[labels] = value
     end
+
+    def increment(value, labels = {})
+      @data[labels] ||= 0
+      @data[labels] += value
+    end
+
+    def decrement(value, labels = {})
+      @data[labels] ||= 0
+      @data[labels] -= value
+    end
   end
 end

--- a/lib/prometheus_exporter/metric/gauge.rb
+++ b/lib/prometheus_exporter/metric/gauge.rb
@@ -23,12 +23,12 @@ module PrometheusExporter::Metric
       @data[labels] = value
     end
 
-    def increment(value, labels = {})
+    def increment(labels = {}, value = 1)
       @data[labels] ||= 0
       @data[labels] += value
     end
 
-    def decrement(value, labels = {})
+    def decrement(labels = {}, value = 1)
       @data[labels] ||= 0
       @data[labels] -= value
     end

--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -46,7 +46,12 @@ module PrometheusExporter::Server
           if !metric
             metric = register_metric_unsafe(obj)
           end
-          metric.observe(obj["value"], obj["keys"])
+          action = obj["action"]
+          if action && supported_actions.include?(action) && metric.respond_to?(action)
+            metric.send(action, obj["value"], obj["keys"])
+          else
+            metric.observe(obj["value"], obj["keys"])
+          end
         end
       end
     end
@@ -85,6 +90,10 @@ module PrometheusExporter::Server
       else
         STDERR.puts "failed to register metric #{obj}"
       end
+    end
+
+    def supported_actions
+      %w[increment decrement]
     end
   end
 end

--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -46,7 +46,7 @@ module PrometheusExporter::Server
           if !metric
             metric = register_metric_unsafe(obj)
           end
-          case obj["action"]
+          case obj["prometheus_exporter_action"]
           when 'increment'
             metric.increment(obj["keys"], obj["value"])
           when 'decrement'

--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -46,9 +46,11 @@ module PrometheusExporter::Server
           if !metric
             metric = register_metric_unsafe(obj)
           end
-          action = obj["action"]
-          if action && supported_actions.include?(action) && metric.respond_to?(action)
-            metric.send(action, obj["value"], obj["keys"])
+          case obj["action"]
+          when 'increment'
+            metric.increment(obj["keys"], obj["value"])
+          when 'decrement'
+            metric.decrement(obj["keys"], obj["value"])
           else
             metric.observe(obj["value"], obj["keys"])
           end
@@ -90,10 +92,6 @@ module PrometheusExporter::Server
       else
         STDERR.puts "failed to register metric #{obj}"
       end
-    end
-
-    def supported_actions
-      %w[increment decrement]
     end
   end
 end

--- a/test/metric/gauge_test.rb
+++ b/test/metric/gauge_test.rb
@@ -69,7 +69,7 @@ module PrometheusExporter::Metric
 
     it "can correctly increment" do
       gauge.observe(1, sam: "ham")
-      gauge.increment(2, sam: "ham")
+      gauge.increment({ sam: "ham" }, 2)
 
       text = <<~TEXT
         # HELP a_gauge my amazing gauge
@@ -82,7 +82,7 @@ module PrometheusExporter::Metric
 
     it "can correctly decrement" do
       gauge.observe(5, sam: "ham")
-      gauge.decrement(2, sam: "ham")
+      gauge.decrement({ sam: "ham" }, 2)
 
       text = <<~TEXT
         # HELP a_gauge my amazing gauge

--- a/test/metric/gauge_test.rb
+++ b/test/metric/gauge_test.rb
@@ -24,7 +24,7 @@ module PrometheusExporter::Metric
       assert_equal(gauge.to_prometheus_text, text)
     end
 
-    it "can correctly increment gauges with labels" do
+    it "can correctly set gauges with labels" do
       gauge.observe(100.5, sam: "ham")
       gauge.observe(5, sam: "ham", fam: "bam")
       gauge.observe(400.11)
@@ -49,6 +49,45 @@ module PrometheusExporter::Metric
         # HELP a_gauge my amazing gauge
         # TYPE a_gauge gauge
         a_gauge 11
+      TEXT
+
+      assert_equal(gauge.to_prometheus_text, text)
+    end
+
+    it "can correctly reset on change with labels" do
+      gauge.observe(1, sam: "ham")
+      gauge.observe(2, sam: "ham")
+
+      text = <<~TEXT
+        # HELP a_gauge my amazing gauge
+        # TYPE a_gauge gauge
+        a_gauge{sam="ham"} 2
+      TEXT
+
+      assert_equal(gauge.to_prometheus_text, text)
+    end
+
+    it "can correctly increment" do
+      gauge.observe(1, sam: "ham")
+      gauge.increment(2, sam: "ham")
+
+      text = <<~TEXT
+        # HELP a_gauge my amazing gauge
+        # TYPE a_gauge gauge
+        a_gauge{sam="ham"} 3
+      TEXT
+
+      assert_equal(gauge.to_prometheus_text, text)
+    end
+
+    it "can correctly decrement" do
+      gauge.observe(5, sam: "ham")
+      gauge.decrement(2, sam: "ham")
+
+      text = <<~TEXT
+        # HELP a_gauge my amazing gauge
+        # TYPE a_gauge gauge
+        a_gauge{sam="ham"} 3
       TEXT
 
       assert_equal(gauge.to_prometheus_text, text)

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -48,7 +48,7 @@ class PrometheusCollectorTest < Minitest::Test
       help: help,
       name: name,
       keys: {key1: 'test1'},
-      action: :increment,
+      prometheus_exporter_action: :increment,
       value: 1
     }.to_json
 
@@ -74,7 +74,7 @@ class PrometheusCollectorTest < Minitest::Test
       help: help,
       name: name,
       keys: {key1: 'test1'},
-      action: :decrement,
+      prometheus_exporter_action: :decrement,
       value: 5
     }.to_json
 


### PR DESCRIPTION
To work like https://github.com/prometheus/client_ruby#gauge. This supports use cases like keeping track of process counts if you only know when processes start and stop but don't have access to something like ps.