### PR TITLE
Register PumaCollector in Server

### DIFF
--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -30,6 +30,7 @@ module PrometheusExporter::Server
       register_collector(ProcessCollector.new)
       register_collector(SidekiqCollector.new)
       register_collector(DelayedJobCollector.new)
+      register_collector(PumaCollector.new)
     end
 
     def register_collector(collector)

--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-minitest", "~> 2.0"
   spec.add_development_dependency "oj", "~> 3.0"
   spec.add_development_dependency "rack-test", "~> 0.8.3"
+  spec.add_development_dependency "minitest-stub-const", "~> 0.6"
   spec.required_ruby_version = '>= 2.3.0'
 end

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -234,4 +234,29 @@ class PrometheusCollectorTest < Minitest::Test
     failed_job.verify
   end
 
+  require 'minitest/stub_const'
+
+  def test_it_can_collect_puma_metrics
+    collector = PrometheusExporter::Server::Collector.new
+    client = PipedClient.new(collector)
+
+    mock_puma = Minitest::Mock.new
+    mock_puma.expect(
+      :stats,
+      '{ "workers": 1, "phase": 0, "booted_workers": 1, "old_workers": 0, "worker_status": [{ "pid": 87819, "index": 0, "phase": 0, "booted": true, "last_checkin": "2018-10-16T11:50:31Z", "last_status": { "backlog":0, "running":8, "pool_capacity":32, "max_threads": 32 } }] }'
+    )
+
+    instrument = PrometheusExporter::Instrumentation::Puma.new
+
+    Object.stub_const(:Puma, mock_puma) do
+      metric = instrument.collect
+      client.send_json metric
+    end
+
+    result = collector.prometheus_metrics_text
+    assert(result.include?("puma_booted_workers_total 1"), "has booted workers")
+    assert(result.include?("puma_request_backlog_total 0"), "has total backlog")
+    assert(result.include?("puma_thread_pool_capacity_total 32"), "has pool capacity")
+    mock_puma.verify
+  end
 end


### PR DESCRIPTION
While trying to use the Puma collector with the `prometheus_exporter` binary, it kept throwing exceptions every time the Puma collector sent stats to /send-metrics.
I was able to fix it by adding the PumaCollector to the registered collectors.