### PR TITLE
mention custom quantiles and buckets in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ histogram.observe(0.2, api: 'twitter')
 
 ```
 
+#### Custom quantiles and buckets
+
+You can also choose custom quantiles for summaries and custom buckets for histograms.
+
+```ruby
+
+summary = PrometheusExporter::Metric::Summary.new("load_time", "time to load page", [0.99, 0.75, 0.5, 0.25])
+histogram = PrometheusExporter::Metric::Summary.new("api_time", "time to call api", buckets: [0.1, 0.5, 1])
+
+```
+
 ### Multi process mode
 
 In some cases (for example, unicorn or puma clusters) you may want to aggregate metrics across multiple processes.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can also choose custom quantiles for summaries and custom buckets for histog
 ```ruby
 
 summary = PrometheusExporter::Metric::Summary.new("load_time", "time to load page", [0.99, 0.75, 0.5, 0.25])
-histogram = PrometheusExporter::Metric::Summary.new("api_time", "time to call api", buckets: [0.1, 0.5, 1])
+histogram = PrometheusExporter::Metric::Histogram.new("api_time", "time to call api", buckets: [0.1, 0.5, 1])
 
 ```
 


### PR DESCRIPTION
@SamSaffron - here's a readme update describing the custom quantiles and buckets. Please let me know if you'd like me to change summary to use an opts hash, or change histogram to use a buckets arg. I feel like they should be consistent but happy to go with whichever consistent approach feels right to you.