### PR TITLE
Check for custom labels in the generic metrics

### DIFF
--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -48,13 +48,19 @@ module PrometheusExporter::Server
           if !metric
             metric = register_metric_unsafe(obj)
           end
+
+          keys = obj["keys"] || {}
+          if obj["custom_labels"]
+            keys = obj["custom_labels"].merge(keys)
+          end
+
           case obj["prometheus_exporter_action"]
           when 'increment'
-            metric.increment(obj["keys"], obj["value"])
+            metric.increment(keys, obj["value"])
           when 'decrement'
-            metric.decrement(obj["keys"], obj["value"])
+            metric.decrement(keys, obj["value"])
           else
-            metric.observe(obj["value"], obj["keys"])
+            metric.observe(obj["value"], keys)
           end
         end
       end


### PR DESCRIPTION
Hello, we're trying to get custom labels on the client for the generic metrics (gauges, counters, etc) and the custom labels option being sent over appeared to be ignored for those.

This fixes that by merging them with the `keys` being sent over, giving preference for anything inside of `keys` over `custom_labels`.