### PR TITLE
allow client queue to be flushed

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ awesome 10
 
 ```
 
+### Short-lived processes
+
+For short-lived processes (e.g. scripts / cron jobs), it is possible that the job finishes before the background worker thread is able to send queued messages.  To ensure that all messages are sent, call the 'flush' method (optionally specifying a max timeout to send queued messages).
+
+```ruby
+require 'prometheus_exporter/client'
+client = PrometheusExporter::Client.default
+gauge = client.register(:gauge, "awesome", "amount of awesome")
+gauge.observe(10)
+client.flush
+```
+
 ### Rails integration
 
 You can easily integrate into any Rack application.

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -86,6 +86,21 @@ module PrometheusExporter
       @metrics << metric
       metric
     end
+    
+    # Ensures queued entries are delivered
+    def flush(timeout=5)
+      begin
+        Timeout::timeout(timeout) do
+          while(@queue.length > 0)
+            Thread.pass
+            sleep 0.01
+          end
+          return true
+        end
+      rescue => e
+      end
+      return false
+    end
 
     def send_json(obj)
       payload = @custom_labels.nil? ? obj : obj.merge(custom_labels: @custom_labels)

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -87,19 +87,14 @@ module PrometheusExporter
       metric
     end
     
-    # Ensures queued entries are delivered
-    def flush(timeout=5)
-      begin
-        Timeout::timeout(timeout) do
-          while(@queue.length > 0)
-            Thread.pass
-            sleep 0.01
-          end
-          return true
-        end
-      rescue => e
+    # Ensures queued entries are delivered for up to timeout seconds
+    def flush(timeout = 5)
+      timeout *= 1000
+      while(@queue.length > 0 && (timeout -= 1) >= 0)
+        Thread.pass
+        sleep 0.001
       end
-      return false
+      @queue.length > 0 ? false : true
     end
 
     def send_json(obj)

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -14,14 +14,14 @@ module PrometheusExporter::Server
       @verbose = verbose
 
       @metrics_total = PrometheusExporter::Metric::Counter.new("collector_metrics_total", "Total metrics processed by exporter web.")
+
       @sessions_total = PrometheusExporter::Metric::Counter.new("collector_sessions_total", "Total send_metric sessions processed by exporter web.")
+
       @bad_metrics_total = PrometheusExporter::Metric::Counter.new("collector_bad_metrics_total", "Total mis-handled metrics by collector.")
-      @metrics_info = PrometheusExporter::Metric::Gauge.new("collector_info", "prometheus_exporter info.")
 
       @metrics_total.observe(0)
       @sessions_total.observe(0)
       @bad_metrics_total.observe(0)
-      @metrics_info.observe(1, {version: PrometheusExporter::VERSION})
 
       access_log, logger = nil
 
@@ -123,7 +123,7 @@ module PrometheusExporter::Server
       end
 
       metrics = []
-      
+
       metrics << add_gauge(
         "collector_working",
         "Is the master process collector able to collect metrics",
@@ -139,7 +139,6 @@ module PrometheusExporter::Server
       metrics << @metrics_total
       metrics << @sessions_total
       metrics << @bad_metrics_total
-      metrics << @metrics_info
 
       <<~TEXT
       #{metrics.map(&:to_prometheus_text).join("\n\n")}

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -14,14 +14,14 @@ module PrometheusExporter::Server
       @verbose = verbose
 
       @metrics_total = PrometheusExporter::Metric::Counter.new("collector_metrics_total", "Total metrics processed by exporter web.")
-
       @sessions_total = PrometheusExporter::Metric::Counter.new("collector_sessions_total", "Total send_metric sessions processed by exporter web.")
-
       @bad_metrics_total = PrometheusExporter::Metric::Counter.new("collector_bad_metrics_total", "Total mis-handled metrics by collector.")
+      @metrics_info = PrometheusExporter::Metric::Gauge.new("collector_info", "prometheus_exporter info.")
 
       @metrics_total.observe(0)
       @sessions_total.observe(0)
       @bad_metrics_total.observe(0)
+      @metrics_info.observe(1, {version: PrometheusExporter::VERSION})
 
       access_log, logger = nil
 
@@ -123,7 +123,7 @@ module PrometheusExporter::Server
       end
 
       metrics = []
-
+      
       metrics << add_gauge(
         "collector_working",
         "Is the master process collector able to collect metrics",
@@ -139,6 +139,7 @@ module PrometheusExporter::Server
       metrics << @metrics_total
       metrics << @sessions_total
       metrics << @bad_metrics_total
+      metrics << @metrics_info
 
       <<~TEXT
       #{metrics.map(&:to_prometheus_text).join("\n\n")}

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require 'prometheus_exporter/client'
+
+# Mock queue reduces its length as it is checked
+class MockQueue
+  def length
+    @queue_length = (@queue_length || 3) - 1
+    @queue_length < 0 ? 0 : @queue_length
+  end
+end
+
+describe PrometheusExporter::Client do
+  
+  before do
+    @client = PrometheusExporter::Client.default
+  end
+
+  describe "flush" do
+    it "sends all queued entries within the timeout" do
+      @client.instance_variable_set(:@queue, MockQueue.new())
+      assert @client.flush(0.1)
+    end
+    it "fails to send queued entries before the timeot" do
+      @client.instance_variable_set(:@queue, [99])
+      refute @client.flush(0.1)
+    end
+  end
+  
+end
+  

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -18,11 +18,11 @@ describe PrometheusExporter::Client do
   describe "flush" do
     it "sends all queued entries within the timeout" do
       @client.instance_variable_set(:@queue, MockQueue.new())
-      assert @client.flush(0.1)
+      assert @client.flush(0.01)
     end
-    it "fails to send queued entries before the timeot" do
+    it "fails to send all entries (timeout)" do
       @client.instance_variable_set(:@queue, [99])
-      refute @client.flush(0.1)
+      refute @client.flush(0.01)
     end
   end
   


### PR DESCRIPTION
Thanks for this product.  Just what we need.

We have a number of really short-lived processes (cron / scripts) than finish before the worker thread can send the queue.  Took me a while to figure out why.

I've added a 'flush' methods that encourages ruby to allow the worker thread process time to send any outstanding queued entries.  This seems to do the trick.  I'm an architect (not a developer), so any feedback on my code and test would be most humbly welcomed.

FYI

We have 2 use cases for prometheus_exporter:
1) Multi-threaded instrumentation of Rails application (passenger) where even if Prometheus ruby client multi-threaded issue is resolved, we don't want to expose metrics in-band as part of the application.  Sending metrics to prometheus_client, and exporting on an alternative port is perfect.
2) Short-running cron/scripts where push-gateway or Node exporter textfile is inappropriate/inadvisable.

Cheers