### PR TITLE
Handle stopping a nil worker_thread client

### DIFF
--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -124,7 +124,7 @@ module PrometheusExporter
       @mutex.synchronize do
         wait_for_empty_queue_with_timeout(wait_timeout_seconds)
         @worker_thread&.kill
-        while @worker_thread.alive?
+        while @worker_thread&.alive?
           sleep 0.001
         end
         @worker_thread = nil


### PR DESCRIPTION
`@worker_thread` in the code below can be nil, as evidenced by the nil check on line 126. Without this change, the following occurs when trying to stop a disconnected client:

```rb
> PrometheusExporter::Client.default.stop         
NoMethodError: undefined method `alive?' for nil:NilClass
```