### PR TITLE
More accurate Unicorn#worker_process_count

### DIFF
--- a/lib/prometheus_exporter/instrumentation/unicorn.rb
+++ b/lib/prometheus_exporter/instrumentation/unicorn.rb
@@ -51,13 +51,13 @@ module PrometheusExporter::Instrumentation
 
     def worker_process_count
       return nil unless File.exist?(@pid_file)
-      pid = File.read(@pid_file)
+      pid = File.read(@pid_file).to_i
 
-      return nil unless pid && pid.to_i > 0
+      return nil unless pid && pid > 0
 
       # find all processes whose parent is the unicorn master
       # but we're actually only interested in the number of processes (= lines of output)
-      result = `ps --no-header -o pid --ppid #{pid}`
+      result = `pgrep -P #{pid} -f unicorn -a`
       result.lines.count
     end
 


### PR DESCRIPTION
When `PrometheusExporter::Instrumentation::Unicorn` is called from
the master process of Unicorn, the previous implementation includes `ps` process itself.
So, it always returns the actual number + 1.

## Background

I'm using this gem inside a container environment (Kubernetes actually).

Running multi-process from `Dockerfile` is not a good practice.
So, I tried to call `PrometheusExporter::Instrumentation::Unicorn` from the config file of Unicorn.

```rb
# config/unicorn.rb
pid_file = ENV.fetch('UNICORN_PID_FILE', '/var/run/unicorn.pid')
pid pid_file

require 'prometheus_exporter'
require 'prometheus_exporter/server'

PrometheusExporter::Server::Runner.new(
  port: 9394,
  unicorn_listen_address: '0.0.0.0:3000',
  unicorn_pid_file: pid_file,
).start

after_fork do |server, worker|
  require 'prometheus_exporter/instrumentation'
  PrometheusExporter::Instrumentation::Process.start(type: 'web')
end
```

Then I noticed that the metric `ruby_unicorn_workers_total` is always +1.