### PR TITLE
Adds "index" and "pid" as labels for Puma metrics

### DIFF
--- a/lib/prometheus_exporter/server/puma_collector.rb
+++ b/lib/prometheus_exporter/server/puma_collector.rb
@@ -33,6 +33,10 @@ module PrometheusExporter::Server
         if m["custom_labels"]
           labels.merge!(m["custom_labels"])
         end
+        if m["index"]
+          labels.merge!(m["index"])
+        if m["pid"]
+          labels.merge!(m["pid"])
 
         PUMA_GAUGES.map do |k, help|
           k = k.to_s


### PR DESCRIPTION
We run puma in docker containers, generally 2 workers with 5 threads each.  We would expect to see puma metrics show up in the exporter as

`prefix_puma_running_threads_total{phase="0"} 10` 

...times the number of puma docker containers pushing metrics into that particular exporter.  So,

`prefix_puma_running_threads_total{phase="0"} 40`

...if we're running 4 containers on a server (we run one exporter per server that all local containers push into).  But, the number remains "10" whether we run 1 or 10 containers.  I suppose this is due to a lack of unique labels per container/worker?

This PR is an attempt to add both "index" and "pid" to the existing "phase" label in hopes that we'll see some true aggregate numbers. 
