### PR TITLE
jobs with retry = false should not count towards dead jobs counter

### DIFF
--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -4,11 +4,15 @@ module PrometheusExporter::Instrumentation
   class Sidekiq
     def self.death_handler
       -> (job, ex) do
-        PrometheusExporter::Client.default.send_json(
-          type: "sidekiq",
-          name: job["class"],
-          dead: true,
-        )
+        job_is_fire_and_forget = job["retry"] == false
+
+        unless job_is_fire_and_forget
+          PrometheusExporter::Client.default.send_json(
+            type: "sidekiq",
+            name: job["class"],
+            dead: true,
+          )
+        end
       end
     end
 


### PR DESCRIPTION
We use the `sidekiq_dead_jobs_total` metric to alert us about jobs that ended up in the dead set.
Jobs with `retry: false` [don't end up in the dead set](https://github.com/mperham/sidekiq/wiki/Error-Handling#dead-set), but still call the `death_handler` and count towards the `sidekiq_dead_jobs_total` metric, leading to inconsistencies between the metric and what you can observe in Sidekiq.

tldr: I assume that jobs with `retry: false` should not count towards `sidekiq_dead_jobs_total`.

What do you think about this?