### PR TITLE
FIX: Use JSON.generate instead of JSON.dump.

### DIFF
--- a/lib/prometheus_exporter.rb
+++ b/lib/prometheus_exporter.rb
@@ -14,7 +14,7 @@ module PrometheusExporter
     def self.parse(obj)
       Oj.compat_load(obj)
     end
-    def self.dump(obj)
+    def self.generate(obj)
       Oj.dump(obj, mode: :compat)
     end
   end

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -89,7 +89,7 @@ module PrometheusExporter
 
     def send_json(obj)
       payload = @custom_labels.nil? ? obj : obj.merge(custom_labels: @custom_labels)
-      send(@json_serializer.dump(payload))
+      send(@json_serializer.generate(payload))
     end
 
     def send(str)

--- a/lib/prometheus_exporter/version.rb
+++ b/lib/prometheus_exporter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PrometheusExporter
-  VERSION = "0.4.12"
+  VERSION = "0.4.13"
 end


### PR DESCRIPTION
Oj.optimize_rails changes JSON.dump behaviour:

```ruby
pry(main)> JSON.dump(metric)
=> "{\":type\":\"web\",\":heap_free_slots\":104076,\":heap_live_slots\":713162,\":major_gc_count\":13,\":minor_gc_count\":43,\":total_allocated_objects\":2535279,\":rss\":0,\":thread_count\":60,\":v8_heap_size\":0,\":v8_used_heap_size\":0,\":v8_physical_size\":0,\":v8_heap_count\":0,\":pid\":39214,\":created_at\":null,\":deferred_jobs_queued\":0,\":active_record_connections_count\":{\"^#1\":[{\":status\":\"busy\"},1],\"^#2\":[{\":status\":\"dead\"},0],\"^#3\":[{\":status\":\"idle\"},0],\"^#4\":[{\":status\":\"waiting\"},0]},\":_type\":\"Process\"}"
pry(main)> JSON.generate(metric)
=> "{\":type\":\"web\",\":heap_free_slots\":104076,\":heap_live_slots\":713162,\":major_gc_count\":13,\":minor_gc_count\":43,\":total_allocated_objects\":2535279,\":rss\":0,\":thread_count\":60,\":v8_heap_size\":0,\":v8_used_heap_size\":0,\":v8_physical_size\":0,\":v8_heap_count\":0,\":pid\":39214,\":created_at\":null,\":deferred_jobs_queued\":0,\":active_record_connections_count\":{\"^#1\":[{\":status\":\"busy\"},1],\"^#2\":[{\":status\":\"dead\"},0],\"^#3\":[{\":status\":\"idle\"},0],\"^#4\":[{\":status\":\"waiting\"},0]},\":_type\":\"Process\"}"

pry(main)> Oj.optimize_rails
=> nil

pry(main)> JSON.dump(metric)
=> "\"#<DiscoursePrometheus::InternalMetric::Process:0x00007fe75c87a0c8>\""
pry(main)> JSON.generate(metric)
=> "{\":type\":\"web\",\":heap_free_slots\":104076,\":heap_live_slots\":713162,\":major_gc_count\":13,\":minor_gc_count\":43,\":total_allocated_objects\":2535279,\":rss\":0,\":thread_count\":60,\":v8_heap_size\":0,\":v8_used_heap_size\":0,\":v8_physical_size\":0,\":v8_heap_count\":0,\":pid\":39214,\":created_at\":null,\":deferred_jobs_queued\":0,\":active_record_connections_count\":{\"^#1\":[{\":status\":\"busy\"},1],\"^#2\":[{\":status\":\"dead\"},0],\"^#3\":[{\":status\":\"idle\"},0],\"^#4\":[{\":status\":\"waiting\"},0]},\":_type\":\"Process\"}"
```