### PR TITLE
Guard socket closing just like socket opening

### DIFF
--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -128,8 +128,8 @@ module PrometheusExporter
           sleep 0.001
         end
         @worker_thread = nil
-      end
         close_socket!
+      end
     end
 
     private


### PR DESCRIPTION
This seems required in order to reliably stop metrics collection while logging the last metric just before stopping the process