### PR TITLE
Explicitly require Client class

### DIFF
--- a/lib/prometheus_exporter/instrumentation.rb
+++ b/lib/prometheus_exporter/instrumentation.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "client"
 require_relative "instrumentation/process"
 require_relative "instrumentation/method_profiler"
 require_relative "instrumentation/sidekiq"


### PR DESCRIPTION
💁 Many of the instrumentation implementations reference `PrometheusExporter::Client` without explicitly `require`ing that class first. Adding a `require` for that class here means they can be included as one file reference by consumers.