### PR TITLE
Allow custom labels for Unicorn metrics

### DIFF
--- a/lib/prometheus_exporter/instrumentation/unicorn.rb
+++ b/lib/prometheus_exporter/instrumentation/unicorn.rb
@@ -9,7 +9,7 @@ end
 module PrometheusExporter::Instrumentation
   # collects stats from unicorn
   class Unicorn
-    def self.start(pid_file:, listener_address:, client:, frequency: 30)
+    def self.start(pid_file:, listener_address:, client: nil, frequency: 30)
       unicorn_collector = new(pid_file: pid_file, listener_address: listener_address)
       client ||= PrometheusExporter::Client.default
       Thread.new do

--- a/lib/prometheus_exporter/server/process_collector.rb
+++ b/lib/prometheus_exporter/server/process_collector.rb
@@ -35,6 +35,7 @@ module PrometheusExporter::Server
 
       @process_metrics.map do |m|
         metric_key = m["metric_labels"].merge("pid" => m["pid"])
+        metric_key.merge!(m["custom_labels"] || {})
 
         PROCESS_GAUGES.map do |k, help|
           k = k.to_s

--- a/lib/prometheus_exporter/server/unicorn_collector.rb
+++ b/lib/prometheus_exporter/server/unicorn_collector.rb
@@ -25,11 +25,13 @@ class PrometheusExporter::Server::UnicornCollector < PrometheusExporter::Server:
     metrics = {}
 
     @unicorn_metrics.map do |m|
+      labels = m["custom_labels"] || {}
+
       UNICORN_GAUGES.map do |k, help|
         k = k.to_s
         if (v = m[k])
           g = metrics[k] ||= PrometheusExporter::Metric::Gauge.new("unicorn_#{k}", help)
-          g.observe(v)
+          g.observe(v, labels)
         end
       end
     end

--- a/test/server/unicorn_collector_test.rb
+++ b/test/server/unicorn_collector_test.rb
@@ -31,4 +31,20 @@ class PrometheusUnicornCollectorTest < Minitest::Test
     ]
     assert_equal expected, metrics.map(&:metric_text)
   end
+
+  def test_collecting_metrics_with_custom_labels
+    collector.collect(
+      'type' => 'unicorn',
+      'workers_total' => 2,
+      'active_workers_total' => 0,
+      'request_backlog_total' => 0,
+      'custom_labels' => {
+        'hostname' => 'a323d2f681e2'
+      }
+    )
+
+    metrics = collector.metrics
+
+    assert(metrics.first.metric_text.include?('unicorn_workers_total{hostname="a323d2f681e2"}'))
+  end
 end


### PR DESCRIPTION
The unicorn and process collectors do not respect the `custom_labels` set on the client.

I need to be able to add a custom label (e.g. host name) to aggregate the unicorn metrics across multiple instances.

With a `hostname` custom label I now get
```
ruby_unicorn_workers_total{hostname="bb4c06c24e81"} 2
ruby_unicorn_workers_total{hostname="d081f77622c7"} 2
```

instead of
```
ruby_unicorn_active_workers_total 2
```

Also makes the client optional for the unicorn instrumentation, so I can make this change to my unicorn config file

```diff
port_http = ENV.fetch('PORT_HTTP')
pid_file = '/tmp/unicorn.pid'

PrometheusExporter::Instrumentation::Unicorn.start(
  pid_file: pid_file,
  listener_address: "0.0.0.0:#{port_http}",
- client: nil,
)
```
