### PR TITLE
Add Delayed Job pending and enqueued counts

### DIFF
--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -21,12 +21,15 @@ module PrometheusExporter::Server
       @delayed_job_duration_seconds_summary.observe(obj["duration"], status: "success") if obj["success"]
       @delayed_job_duration_seconds_summary.observe(obj["duration"], status: "failed")  if !obj["success"]
       @delayed_job_attempts_summary.observe(obj["attempts"]) if obj["success"]
+      @delayed_jobs_enqueued.observe(obj["enqueued"])
+      @delayed_jobs_pending.observe(obj["pending"])
     end
 
     def metrics
       if @delayed_jobs_total
         [@delayed_job_duration_seconds, @delayed_jobs_total, @delayed_failed_jobs_total,
-         @delayed_jobs_max_attempts_reached_total, @delayed_job_duration_seconds_summary, @delayed_job_attempts_summary]
+         @delayed_jobs_max_attempts_reached_total, @delayed_job_duration_seconds_summary, @delayed_job_attempts_summary,
+         @delayed_jobs_enqueued, @delayed_jobs_pending]
       else
         []
       end
@@ -44,6 +47,14 @@ module PrometheusExporter::Server
         @delayed_jobs_total =
         PrometheusExporter::Metric::Counter.new(
           "delayed_jobs_total", "Total number of delayed jobs executed.")
+
+        @delayed_jobs_enqueued =
+        PrometheusExporter::Metric::Gauge.new(
+          "delayed_jobs_enqueued", "Number of enqueued delayed jobs.")
+
+        @delayed_jobs_pending =
+        PrometheusExporter::Metric::Gauge.new(
+          "delayed_jobs_pending", "Number of pending delayed jobs.")
 
         @delayed_failed_jobs_total =
         PrometheusExporter::Metric::Counter.new(

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -223,7 +223,7 @@ class PrometheusCollectorTest < Minitest::Test
     job.expect(:handler, "job_class: Class")
     job.expect(:attempts, 0)
 
-    instrument.call(job, 20, nil, "default") do
+    instrument.call(job, 20, 10, 0, nil, "default") do
       # nothing
     end
 
@@ -232,7 +232,7 @@ class PrometheusCollectorTest < Minitest::Test
     failed_job.expect(:attempts, 1)
 
     begin
-      instrument.call(failed_job, 25, nil, "default") do
+      instrument.call(failed_job, 25, 10, 0, nil, "default") do
         boom
       end
     rescue
@@ -243,6 +243,8 @@ class PrometheusCollectorTest < Minitest::Test
     assert(result.include?("delayed_failed_jobs_total{job_name=\"Object\"} 1"), "has failed job")
     assert(result.include?("delayed_jobs_total{job_name=\"Class\"} 1"), "has working job")
     assert(result.include?("delayed_job_duration_seconds"), "has duration")
+    assert(result.include?("delayed_jobs_enqueued 10"), "has enqueued count")
+    assert(result.include?("delayed_jobs_pending 0"), "has pending count")
     job.verify
     failed_job.verify
   end
@@ -257,7 +259,7 @@ class PrometheusCollectorTest < Minitest::Test
     job.expect(:handler, "job_class: Class")
     job.expect(:attempts, 0)
 
-    instrument.call(job, 25, nil, "default") do
+    instrument.call(job, 25, 10, 0, nil, "default") do
       # nothing
     end
 
@@ -266,7 +268,7 @@ class PrometheusCollectorTest < Minitest::Test
     failed_job.expect(:attempts, 1)
 
     begin
-      instrument.call(failed_job, 25, nil, "default") do
+      instrument.call(failed_job, 25, 10, 0, nil, "default") do
         boom
       end
     rescue
@@ -277,6 +279,8 @@ class PrometheusCollectorTest < Minitest::Test
     assert(result.include?('delayed_failed_jobs_total{job_name="Object",service="service1"} 1'), "has failed job")
     assert(result.include?('delayed_jobs_total{job_name="Class",service="service1"} 1'), "has working job")
     assert(result.include?('delayed_job_duration_seconds{job_name="Class",service="service1"}'), "has duration")
+    assert(result.include?("delayed_jobs_enqueued 10"), "has enqueued count")
+    assert(result.include?("delayed_jobs_pending 0"), "has pending count")
     job.verify
     failed_job.verify
   end


### PR DESCRIPTION
Adds
```
# HELP ruby_delayed_jobs_enqueued Number of enqueued delayed jobs.
# TYPE ruby_delayed_jobs_enqueued gauge
ruby_delayed_jobs_enqueued 2

# HELP ruby_delayed_jobs_pending Number of pending delayed jobs.
# TYPE ruby_delayed_jobs_pending gauge
ruby_delayed_jobs_pending 0
```

In order to scale the number of workers correctly it's useful to track the number of pending delayed jobs.