### PR TITLE
FIX: replace `hostname` calls with `Socket#gethostname`

### DIFF
--- a/lib/prometheus_exporter/instrumentation/active_record.rb
+++ b/lib/prometheus_exporter/instrumentation/active_record.rb
@@ -57,7 +57,7 @@ module PrometheusExporter::Instrumentation
     def hostname
       @hostname ||=
         begin
-          `hostname`.strip
+          Socket.gethostname
         rescue => e
           STDERR.puts "Unable to lookup hostname #{e}"
           "unknown-host"

--- a/lib/prometheus_exporter/instrumentation/process.rb
+++ b/lib/prometheus_exporter/instrumentation/process.rb
@@ -48,7 +48,7 @@ module PrometheusExporter::Instrumentation
     def hostname
       @hostname ||=
         begin
-          `hostname`.strip
+          Socket.gethostname
         rescue => e
           STDERR.puts "Unable to lookup hostname #{e}"
           "unknown-host"


### PR DESCRIPTION
Hi there! :wave: Thank you so very much for this project — we at Plex have been using for quite some time with great results. :raised_hands: Unfortunately, after a recent upgrade to the latest version, we have started noticing quite a few zombie processes spawning from our puma workers, which we have tracked down to the `hostname` calls made by `prometheus_exporter` — which have been introduced fairly recently. 

Luckily, the built-in ruby alternative `Socket#gethostname` (available from 1.9.3) doesn't cause these extra processes, returns the same value, and it saves us the `String#strip` call. Any chance we could get this implementation swapped in?

Thanks a million in advance! :wave: 