### PR TITLE
FEATURE: Allow configuring the default client's host and port via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To learn more see [Instrumenting Rails with Prometheus](https://samsaffron.com/a
   * [GraphQL support](#graphql-support)
   * [Metrics default prefix / labels](#metrics-default-prefix--labels)
   * [Client default labels](#client-default-labels)
+  * [Client default host](#client-default-host)
 * [Transport concerns](#transport-concerns)
 * [JSON generation and parsing](#json-generation-and-parsing)
 * [Contributing](#contributing)
@@ -195,7 +196,7 @@ This collects activerecord connection pool metrics.
 
 It supports injection of custom labels and the connection config options (`username`, `database`, `host`, `port`) as labels.
 
-For Puma single mode 
+For Puma single mode
 ```ruby
 #in puma.rb
 require 'prometheus_exporter/instrumentation'
@@ -560,6 +561,9 @@ Will result in:
 http_requests_total{controller="home","action"="index",service="app-server-01",app_name="app-01"} 2
 http_requests_total{service="app-server-01",app_name="app-01"} 1
 ```
+### Client default host
+
+By default, `PrometheusExporter::Client.default` connects to `localhost:9394`. If your setup requires this (e.g. when using `docker-compose`), you can change the default host and port by setting the environment variables `PROMETHEUS_EXPORTER_HOST` and `PROMETHEUS_EXPORTER_PORT`.
 
 ## Transport concerns
 

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -53,7 +53,14 @@ module PrometheusExporter
     MAX_SOCKET_AGE = 25
     MAX_QUEUE_SIZE = 10_000
 
-    def initialize(host: 'localhost', port: PrometheusExporter::DEFAULT_PORT, max_queue_size: nil, thread_sleep: 0.5, json_serializer: nil, custom_labels: nil)
+    def initialize(
+      host: ENV.fetch('PROMETHEUS_EXPORTER_HOST', 'localhost'),
+      port: ENV.fetch('PROMETHEUS_EXPORTER_PORT', PrometheusExporter::DEFAULT_PORT),
+      max_queue_size: nil,
+      thread_sleep: 0.5,
+      json_serializer: nil,
+      custom_labels: nil
+    )
       @metrics = []
 
       @queue = Queue.new


### PR DESCRIPTION
In my docker-compose setup, I have to run prometheus_exporter server and client in different containers on the same network. By default, all the integrations use `PrometheusExporter::Client.default` which uses `localhost`, all the time

This MR defaults host and port to also look at the environment variable `PROMETHEUS_EXPORTER_HOST` and `PROMETHEUS_EXPORTER_PORT` to allow easy override using the environment configuration.