### PR TITLE
Add HTTP status to http_duration_seconds

### DIFF
--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -6,9 +6,10 @@ require 'prometheus_exporter/client'
 class PrometheusExporter::Middleware
   MethodProfiler = PrometheusExporter::Instrumentation::MethodProfiler
 
-  def initialize(app, config = { instrument: true, client: nil })
+  def initialize(app, config = { instrument: true, client: nil, http_labels_on_duration: false })
     @app = app
     @client = config[:client] || PrometheusExporter::Client.default
+    @http_labels_on_duration = config[:http_labels_on_duration]
 
     if config[:instrument]
       if defined? Redis::Client
@@ -50,7 +51,8 @@ class PrometheusExporter::Middleware
       queue_time: queue_time,
       action: action,
       controller: controller,
-      status: status
+      status: status,
+      http_labels_on_duration: @http_labels_on_duration
     )
   end
 

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -62,11 +62,16 @@ module PrometheusExporter::Server
       }
       custom_labels = obj['custom_labels']
       labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
+      http_labels = labels.merge(status: obj["status"])
 
-      @http_requests_total.observe(1, labels.merge(status: obj["status"]))
+      @http_requests_total.observe(1, http_labels)
 
       if timings = obj["timings"]
-        @http_duration_seconds.observe(timings["total_duration"], labels)
+        if obj['http_labels_on_duration']
+          @http_duration_seconds.observe(timings["total_duration"], http_labels)
+        else
+          @http_duration_seconds.observe(timings["total_duration"], labels)
+        end
         if redis = timings["redis"]
           @http_redis_duration_seconds.observe(redis["duration"], labels)
         end

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -41,11 +41,51 @@ class PrometheusWebCollectorTest < Minitest::Test
       },
       "action" => 'index',
       "controller" => 'home',
-      "status" => 200
+      "status" => 200,
+      "http_labels_on_duration" => false
     )
 
     metrics = collector.metrics
     assert_equal 5, metrics.size
+
+    http_duration_seconds = metrics[1].metric_text
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",quantile="0.99"}'), "has duration quantile 0.99")
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",quantile="0.9"}'), "has duration quantile 0.9")
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",quantile="0.5"}'), "has duration quantile 0.5")
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",quantile="0.1"}'), "has duration quantile 0.1")
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",quantile="0.01"}'), "has duration quantile 0.01")
+  end
+
+  def test_collecting_metrics_with_http_labels_on_duration
+    collector.collect(
+      "type" => "web",
+      "timings" => {
+        "sql" => {
+          duration: 0.5,
+          count: 40
+        },
+        "redis" => {
+          duration: 0.03,
+          count: 4
+        },
+        "queue" => 0.03,
+        "total_duration" => 1.0
+      },
+      "action" => 'index',
+      "controller" => 'home',
+      "status" => 200,
+      "http_labels_on_duration" => true
+    )
+
+    metrics = collector.metrics
+    assert_equal 5, metrics.size
+
+    http_duration_seconds = metrics[1].metric_text
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",status="200",quantile="0.99"}'), "has duration quantile 0.99")
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",status="200",quantile="0.9"}'), "has duration quantile 0.9")
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",status="200",quantile="0.5"}'), "has duration quantile 0.5")
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",status="200",quantile="0.1"}'), "has duration quantile 0.1")
+    assert(http_duration_seconds.include?('http_duration_seconds{controller="home",action="index",status="200",quantile="0.01"}'), "has duration quantile 0.01")
   end
 
   def test_collecting_metrics_with_custom_labels


### PR DESCRIPTION
It'd be great to compare counts and duration by HTTP status code.