### PR TITLE
Move sidekiq_job_duration_seconds from Counter to Summary

### DIFF
--- a/lib/prometheus_exporter/server/sidekiq_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_collector.rb
@@ -52,7 +52,7 @@ module PrometheusExporter::Server
       if !@sidekiq_jobs_total
 
         @sidekiq_job_duration_seconds =
-        PrometheusExporter::Metric::Counter.new(
+        PrometheusExporter::Metric::Summary.new(
           "sidekiq_job_duration_seconds", "Total time spent in sidekiq jobs.")
 
         @sidekiq_jobs_total =

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -290,7 +290,11 @@ class PrometheusCollectorTest < Minitest::Test
 
     assert(result.include?('sidekiq_failed_jobs_total{job_name="FalseClass",service="service1"} 1'), "has failed job")
     assert(result.include?('sidekiq_jobs_total{job_name="String",service="service1"} 1'), "has working job")
-    assert(result.include?('sidekiq_job_duration_seconds{job_name="FalseClass",service="service1"}'), "has duration")
+    assert(result.include?('sidekiq_job_duration_seconds{job_name="FalseClass",service="service1",quantile="0.99"}'), "has duration quantile 0.99")
+    assert(result.include?('sidekiq_job_duration_seconds{job_name="FalseClass",service="service1",quantile="0.9"}'), "has duration quantile 0.9")
+    assert(result.include?('sidekiq_job_duration_seconds{job_name="FalseClass",service="service1",quantile="0.5"}'), "has duration quantile 0.5")
+    assert(result.include?('sidekiq_job_duration_seconds{job_name="FalseClass",service="service1",quantile="0.1"}'), "has duration quantile 0.1")
+    assert(result.include?('sidekiq_job_duration_seconds{job_name="FalseClass",service="service1",quantile="0.01"}'), "has duration quantile 0.01")
     assert(result.include?('sidekiq_jobs_total{job_name="WrappedClass",service="service1"} 1'), "has sidekiq working job from ActiveJob")
   end
 


### PR DESCRIPTION
I'd love to be able to see p99, p90, p50 for Sidekiq job durations.