### PR TITLE
Parse Sidekiq Delayed class names

### DIFF
--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -286,12 +286,20 @@ class PrometheusCollectorTest < Minitest::Test
       end
     end
 
+    delayed_worker = {}
+    delayed_worker.stub(:class, "Sidekiq::Extensions::DelayedClass") do
+      instrument.call(delayed_worker, { 'args' => [ "---\n- !ruby/class 'String'\n- :foo\n- -" ] }, "default") do
+        # nothing
+      end
+    end
+
     result = collector.prometheus_metrics_text
 
     assert(result.include?('sidekiq_failed_jobs_total{job_name="FalseClass",service="service1"} 1'), "has failed job")
     assert(result.include?('sidekiq_jobs_total{job_name="String",service="service1"} 1'), "has working job")
     assert(result.include?('sidekiq_job_duration_seconds{job_name="FalseClass",service="service1"}'), "has duration")
     assert(result.include?('sidekiq_jobs_total{job_name="WrappedClass",service="service1"} 1'), "has sidekiq working job from ActiveJob")
+    assert(result.include?('sidekiq_jobs_total{job_name="String#foo",service="service1"} 1'), "has sidekiq delayed class")
   end
 
   def test_it_can_collect_shoryuken_metrics_with_custom_lables


### PR DESCRIPTION
Adjusting the job name for Sidekiq Delayed classes gives users more insight into which Mailer, Model or Class methods are contributing to high counts or durations. For example, `UserMailer.delay.welcome(user.id)` would now have the job name of `UserMailer#welcome` instead of `Sidekiq::Extensions::DelayedMailer`.