### PR TITLE
Use unfrozen version of Symbol#to_s

### DIFF
--- a/lib/prometheus_exporter/instrumentation/active_record.rb
+++ b/lib/prometheus_exporter/instrumentation/active_record.rb
@@ -69,7 +69,7 @@ module PrometheusExporter::Instrumentation
 
         labels_from_config = pool.spec.config
           .select { |k, v| @config_labels.include? k }
-          .map { |k, v| [k.to_s.prepend("dbconfig_"), v] }
+          .map { |k, v| [k.to_s.dup.prepend("dbconfig_"), v] }
 
         labels = @metric_labels.merge(pool_name: pool.spec.name).merge(Hash[labels_from_config])
 


### PR DESCRIPTION
Makes it compatible with [Shopify/symbol-fstring](https://github.com/Shopify/symbol-fstring)

Otherwise it throws `Prometheus Exporter Failed To Collect Process Stats can't modify frozen String: "database"` periodically.