### PR TITLE
Add support for HTTPAuth::BasicAuth in prometheus_exporter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.6.0 - 10-11-2020
+
+- FEATURE: add support for basic-auth in the prometheus_exporter web server
+
 0.5.3 - 29-07-2020
 
 - FEATURE: added #remove to all metric types so users can remove specific labels if needed

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ $ bundle exec prometheus_exporter
 | Summary | `http_sql_duration_seconds`²    | Time spent in HTTP reqs in SQL in seconds                   |
 | Summary | `http_queue_duration_seconds`³  | Time spent queueing the request in load balancer in seconds |
 
-All metrics have a `controller` and an `action` label.  
-`http_requests_total` additionally has a (HTTP response) `status` label.  
+All metrics have a `controller` and an `action` label.
+`http_requests_total` additionally has a (HTTP response) `status` label.
 
 To add your own labels to the default metrics, create a subclass of `PrometheusExporter::Middleware`, override `custom_labels`, and use it in your initializer.
 ```ruby
@@ -218,9 +218,9 @@ class MyMiddleware < PrometheusExporter::Middleware
 end
 ```
 
-¹) Only available when Redis is used.  
-²) Only available when Mysql or PostgreSQL are used.  
-³) Only available when [Instrumenting Request Queueing Time](#instrumenting-request-queueing-time) is set up.  
+¹) Only available when Redis is used.
+²) Only available when Mysql or PostgreSQL are used.
+³) Only available when [Instrumenting Request Queueing Time](#instrumenting-request-queueing-time) is set up.
 
 #### Activerecord Connection Pool Metrics
 
@@ -402,7 +402,7 @@ This metric has a `job_name` label and a `queue` label.
 
 Both metrics will have a `queue` label with the name of the queue.
 
-_See [Metrics collected by Process Instrumentation](#metrics-collected-by-process-instrumentation) for a list of metrics the Process instrumentation will produce._  
+_See [Metrics collected by Process Instrumentation](#metrics-collected-by-process-instrumentation) for a list of metrics the Process instrumentation will produce._
 
 #### Shoryuken metrics
 
@@ -426,7 +426,7 @@ end
 | Counter | `shoryuken_restarted_jobs_total` | Total number of shoryuken jobs that we restarted because of a shoryuken shutdown |
 | Counter | `shoryuken_failed_jobs_total`    | Total number of failed shoryuken jobs                                            |
 
-All metrics have labels for `job_name` and `queue_name`.  
+All metrics have labels for `job_name` and `queue_name`.
 
 #### Delayed Job plugin
 
@@ -471,7 +471,7 @@ end
 | Counter | `hutch_jobs_total`           | Total number of hutch jobs executed     |
 | Counter | `hutch_failed_jobs_total`    | Total number failed hutch jobs executed |
 
-All metrics have a `job_name` label. 
+All metrics have a `job_name` label.
 
 #### Instrumenting Request Queueing Time
 
@@ -509,7 +509,7 @@ end
 | Gauge | `puma_thread_pool_capacity_total` | Number of puma threads available at current scale           |
 | Gauge | `puma_max_threads_total`          | Number of puma threads at available at max scale            |
 
-All metrics may have a `phase` label.   
+All metrics may have a `phase` label.
 
 ### Unicorn process metrics
 
@@ -707,6 +707,25 @@ ruby_web_requests{hostname="app-server-01"} 1
 When running the process for `prometheus_exporter` using `bin/prometheus_exporter`, there are several configurations that
 can be passed in:
 
+```
+Usage: prometheus_exporter [options]
+    -p, --port INTEGER               Port exporter should listen on (default: 9394)
+    -b, --bind STRING                IP address exporter should listen on (default: localhost)
+    -t, --timeout INTEGER            Timeout in seconds for metrics endpoint (default: 2)
+        --prefix METRIC_PREFIX       Prefix to apply to all metrics (default: ruby_)
+        --label METRIC_LABEL         Label to apply to all metrics (default: {})
+    -c, --collector FILE             (optional) Custom collector to run
+    -a, --type-collector FILE        (optional) Custom type collectors to run in main collector
+    -v, --verbose
+        --auth FILE                  (optional) enable basic authentication using a htpasswd FILE
+        --realm REALM                (optional) Use REALM for basic authentication (default: "Prometheus Exporter")
+        --unicorn-listen-address ADDRESS
+                                     (optional) Address where unicorn listens on (unix or TCP address)
+        --unicorn-master PID_FILE    (optional) PID file of unicorn master process to monitor unicorn
+```
+
+#### Example
+
 The following will run the process at
 - Port `8080` (default `9394`)
 - Bind to `0.0.0.0` (default `localhost`)
@@ -721,6 +740,29 @@ prometheus_exporter -p 8080 \
                     --label '{"environment": "integration", "foo": "bar"}' \
                     --prefix 'foo_'
 ```
+
+#### Enabling Basic Authentication
+
+If you desire authentication on your `/metrics` route, you can enable basic authentication with the `--auth` option.
+
+```
+$ prometheus_exporter --auth my-htpasswd-file
+```
+
+Additionally, the `--realm` option may be used to provide a customized realm for the challenge request.
+
+Notes:
+
+* You will need to create a `htpasswd` formatted file before hand which contains one or more user:password entries
+* Only the basic `crypt` encryption is currently supported
+
+A simple `htpasswd` file can be created with the Apache `htpasswd` utility; e.g:
+
+```
+$ htpasswd -cdb my-htpasswd-file my-user my-unencrypted-password
+```
+
+This will create a file named `my-htpasswd-file` which is suitable for use the `--auth` option.
 
 ### Client default labels
 

--- a/bin/prometheus_exporter
+++ b/bin/prometheus_exporter
@@ -47,6 +47,12 @@ def run
     opt.on('-v', '--verbose') do |o|
       options[:verbose] = true
     end
+    opt.on('--auth FILE', String, "(optional) enable basic authentication using a htpasswd FILE") do |o|
+      options[:auth] = o
+    end
+    opt.on('--realm REALM', String, "(optional) Use REALM for basic authentication (default: \"#{PrometheusExporter::DEFAULT_REALM}\")") do |o|
+      options[:realm] = o
+    end
 
     opt.on('--unicorn-listen-address ADDRESS', String, '(optional) Address where unicorn listens on (unix or TCP address)') do |o|
       options[:unicorn_listen_address] = o
@@ -56,6 +62,17 @@ def run
       options[:unicorn_pid_file] = o
     end
   end.parse!
+
+  if options.has_key?(:realm) && !options.has_key?(:auth)
+    STDERR.puts "[Warn] Providing REALM without AUTH has no effect"
+  end
+
+  if options.has_key?(:auth)
+    unless File.exist?(options[:auth]) && File.readable?(options[:auth])
+      STDERR.puts "[Error] The AUTH file either doesn't exist or we don't have access to it"
+      exit 1
+    end
+  end
 
   if custom_collector_filename
     eval File.read(custom_collector_filename), nil, File.expand_path(custom_collector_filename)

--- a/lib/prometheus_exporter.rb
+++ b/lib/prometheus_exporter.rb
@@ -11,6 +11,7 @@ module PrometheusExporter
   DEFAULT_PREFIX = 'ruby_'
   DEFAULT_LABEL = {}
   DEFAULT_TIMEOUT = 2
+  DEFAULT_REALM = 'Prometheus Exporter'
 
   class OjCompat
     def self.parse(obj)

--- a/lib/prometheus_exporter/server/runner.rb
+++ b/lib/prometheus_exporter/server/runner.rb
@@ -15,6 +15,8 @@ module PrometheusExporter::Server
       @collector_class = nil
       @type_collectors = nil
       @prefix = nil
+      @auth = nil
+      @realm = nil
 
       options.each do |k, v|
         send("#{k}=", v) if self.class.method_defined?("#{k}=")
@@ -40,12 +42,20 @@ module PrometheusExporter::Server
         )
       end
 
-      server = server_class.new port: port, bind: bind, collector: collector, timeout: timeout, verbose: verbose
+      server = server_class.new(port: port, bind: bind, collector: collector, timeout: timeout, verbose: verbose, auth: auth, realm: realm)
       server.start
     end
 
     attr_accessor :unicorn_listen_address, :unicorn_pid_file
-    attr_writer :prefix, :port, :bind, :collector_class, :type_collectors, :timeout, :verbose, :server_class, :label
+    attr_writer :prefix, :port, :bind, :collector_class, :type_collectors, :timeout, :verbose, :server_class, :label, :auth, :realm
+
+    def auth
+      @auth || nil
+    end
+
+    def realm
+      @realm || PrometheusExporter::DEFAULT_REALM
+    end
 
     def prefix
       @prefix || PrometheusExporter::DEFAULT_PREFIX

--- a/lib/prometheus_exporter/version.rb
+++ b/lib/prometheus_exporter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PrometheusExporter
-  VERSION = '0.5.3'
+  VERSION = '0.6.0'
 end

--- a/test/server/runner_test.rb
+++ b/test/server/runner_test.rb
@@ -51,6 +51,8 @@ class PrometheusRunnerTest < Minitest::Test
     assert_equal(runner.type_collectors, [])
     assert_equal(runner.verbose, false)
     assert_empty(runner.label)
+    assert_nil(runner.auth)
+    assert_equal(runner.realm, 'Prometheus Exporter')
   end
 
   def test_runner_custom_options
@@ -61,7 +63,9 @@ class PrometheusRunnerTest < Minitest::Test
       collector_class: CollectorMock,
       type_collectors: [TypeCollectorMock],
       verbose: true,
-      label: { environment: 'integration' }
+      label: { environment: 'integration' },
+      auth: 'my_htpasswd_file',
+      realm: 'test realm'
     )
 
     assert_equal(runner.prefix, 'new_')
@@ -71,6 +75,8 @@ class PrometheusRunnerTest < Minitest::Test
     assert_equal(runner.type_collectors, [TypeCollectorMock])
     assert_equal(runner.verbose, true)
     assert_equal(runner.label, { environment: 'integration' })
+    assert_equal(runner.auth, 'my_htpasswd_file')
+    assert_equal(runner.realm, 'test realm')
 
     reset_base_metric_label
   end
@@ -84,6 +90,8 @@ class PrometheusRunnerTest < Minitest::Test
     assert_equal(runner.port, 9394)
     assert_equal(runner.timeout, 2)
     assert_equal(runner.verbose, false)
+    assert_nil(runner.auth)
+    assert_equal(runner.realm, 'Prometheus Exporter')
     assert_equal(PrometheusExporter::Metric::Base.default_labels, { environment: 'integration' })
     assert_instance_of(PrometheusExporter::Server::Collector, runner.collector)
 


### PR DESCRIPTION
Adds support for basic authentication in the prometheus_exporter CLI application.

* When given a `htpasswd` filename via the `--auth` command line argument, the server will use this file to authenticate any requests to the `/metrics` endpoint.
* Optionally, a custom REALM may be provided via the `--realm` argument. The default REALM is "Prometheus Exporter"

_Note: the htpasswd file must be created beforehand and, due to limitations in WEBrick, only crypt is supported._