### PR TITLE
Don't attempt to close a socket that is already closed.

### DIFF
--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -188,7 +188,7 @@ module PrometheusExporter
 
     def close_socket!
       begin
-        if @socket
+        if @socket && !@socket.closed?
           @socket.write("0\r\n")
           @socket.write("\r\n")
           @socket.flush


### PR DESCRIPTION
This change is a result of issues running prometheus_exporter with delayed_job.

delayed_job uses the daemons gem which closes all existing IO objects (https://github.com/thuehlinger/daemons/blob/76a934ab333788964a5d7587648cfc98ffd2b150/lib/daemons/daemonize.rb#L121).  After this happens, the PrometheusExporter::Client stops being able to send metrics and instead prints the following error:
> Prometheus Exporter, failed to send message closed stream

This change allows PrometheusExporter::Client to detect the closed socket after 25 seconds (MAX_SOCKET_AGE) and clean it up.