### PR TITLE
Better extendability

### DIFF
--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -56,14 +56,11 @@ module PrometheusExporter::Server
     end
 
     def observe(obj)
-      default_labels = {
-        controller: obj['controller'] || 'other',
-        action: obj['action'] || 'other'
-      }
+      default_labels = obj['default_labels']
       custom_labels = obj['custom_labels']
       labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
 
-      @http_requests_total.observe(1, labels.merge(status: obj["status"]))
+      @http_requests_total.observe(1, labels)
 
       if timings = obj["timings"]
         @http_duration_seconds.observe(timings["total_duration"], labels)

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -12,11 +12,13 @@ class PrometheusWebCollectorTest < Minitest::Test
 
   def test_collecting_metrics_without_specific_timings
     collector.collect(
-      type: "web",
-      timings: nil,
-      action: 'index',
-      controller: 'home',
-      status: 200
+      "type" => "web",
+      "timings" => nil,
+      "default_labels" => {
+        "action" => 'index',
+        "controller" => 'home',
+        "status": 200
+      },
     )
 
     metrics = collector.metrics
@@ -39,9 +41,11 @@ class PrometheusWebCollectorTest < Minitest::Test
         "queue" => 0.03,
         "total_duration" => 1.0
       },
-      "action" => 'index',
-      "controller" => 'home',
-      "status" => 200
+      'default_labels' => {
+        'action' => 'index',
+        'controller' => 'home',
+        "status" => 200
+      },
     )
 
     metrics = collector.metrics
@@ -52,9 +56,11 @@ class PrometheusWebCollectorTest < Minitest::Test
     collector.collect(
       'type' => 'web',
       'timings' => nil,
-      'action' => 'index',
-      'controller' => 'home',
-      'status' => 200,
+      'default_labels' => {
+        'controller' => 'home',
+        'action' => 'index',
+        'status' => 200,
+      },
       'custom_labels' => {
         'service' => 'service1'
       }
@@ -63,6 +69,6 @@ class PrometheusWebCollectorTest < Minitest::Test
     metrics = collector.metrics
 
     assert_equal 5, metrics.size
-    assert(metrics.first.metric_text.include?('http_requests_total{controller="home",action="index",service="service1",status="200"}'))
+    assert(metrics.first.metric_text.include?('http_requests_total{controller="home",action="index",status="200",service="service1"}'))
   end
 end


### PR DESCRIPTION
Hello!

I'd like to use prometheus_exporter, however I didn't like the way it was adding default labels.
My issue is that on my custom rack app controller and action always resolves to `other`.

I've modified prometheus_exporter in order to allow more flexibility when it comes to extendability.
This change allows me to create custom middleware by extending PrometheusExporter::Middleware and implement proper default tags (in my case, status, method and path. Similar how it's done in [prometheus-client](https://github.com/prometheus/client_ruby/blob/master/lib/prometheus/middleware/collector.rb#L69))

Please review my proposed change and merge, if deemed acceptable or please do let me know, what to improve.

Here's example metrics from my branch
```
# HELP ruby_http_requests_total Total HTTP requests from web app.
# TYPE ruby_http_requests_total counter
ruby_http_requests_total{path="/api/v1/persons",method="GET",status="200"} 1
ruby_http_requests_total{path="/api/v1/teams",method="GET",status="200"} 1
ruby_http_requests_total{path="/api/v1/persons/:id",method="PUT",status="200"} 1

# HELP ruby_http_duration_seconds Time spent in HTTP reqs in seconds.
# TYPE ruby_http_duration_seconds summary
ruby_http_duration_seconds{path="/api/v1/persons",method="GET",status="200",quantile="0.99"} 0.2886974339999142
ruby_http_duration_seconds{path="/api/v1/persons",method="GET",status="200",quantile="0.9"} 0.2886974339999142
ruby_http_duration_seconds{path="/api/v1/persons",method="GET",status="200",quantile="0.5"} 0.2886974339999142
ruby_http_duration_seconds{path="/api/v1/persons",method="GET",status="200",quantile="0.1"} 0.2886974339999142
ruby_http_duration_seconds{path="/api/v1/persons",method="GET",status="200",quantile="0.01"} 0.2886974339999142
ruby_http_duration_seconds_sum{path="/api/v1/persons",method="GET",status="200"} 0.2886974339999142
ruby_http_duration_seconds_count{path="/api/v1/persons",method="GET",status="200"} 1
ruby_http_duration_seconds{path="/api/v1/teams",method="GET",status="200",quantile="0.99"} 0.009880661998977303
ruby_http_duration_seconds{path="/api/v1/teams",method="GET",status="200",quantile="0.9"} 0.009880661998977303
ruby_http_duration_seconds{path="/api/v1/teams",method="GET",status="200",quantile="0.5"} 0.009880661998977303
ruby_http_duration_seconds{path="/api/v1/teams",method="GET",status="200",quantile="0.1"} 0.009880661998977303
ruby_http_duration_seconds{path="/api/v1/teams",method="GET",status="200",quantile="0.01"} 0.009880661998977303
ruby_http_duration_seconds_sum{path="/api/v1/teams",method="GET",status="200"} 0.009880661998977303
ruby_http_duration_seconds_count{path="/api/v1/teams",method="GET",status="200"} 1
ruby_http_duration_seconds{path="/api/v1/persons/:id",method="PUT",status="200",quantile="0.99"} 0.3039839339999162
ruby_http_duration_seconds{path="/api/v1/persons/:id",method="PUT",status="200",quantile="0.9"} 0.3039839339999162
ruby_http_duration_seconds{path="/api/v1/persons/:id",method="PUT",status="200",quantile="0.5"} 0.3039839339999162
ruby_http_duration_seconds{path="/api/v1/persons/:id",method="PUT",status="200",quantile="0.1"} 0.3039839339999162
ruby_http_duration_seconds{path="/api/v1/persons/:id",method="PUT",status="200",quantile="0.01"} 0.3039839339999162
ruby_http_duration_seconds_sum{path="/api/v1/persons/:id",method="PUT",status="200"} 0.3039839339999162
ruby_http_duration_seconds_count{path="/api/v1/persons/:id",method="PUT",status="200"} 1
```


NOTE: I was confused a bit about tests as in some location strings where used in some other symbols were used. Given that you appear to send `Oj.dump(obj, mode: :compat)` which converts symbols to strings, I adjusted some tests that were failing due to my change to use strings.

Also I find it a lot of merging.
Thing to consider: perhaps just implement labels method, that returns default_labels and then when extending middleware, just override metrics method call super and merge labels in one place.

```
class AMiddleware
  def labels(env, result)
    status = (result && result[0]) || -1
    params = env["action_dispatch.request.parameters"]
    action = controller = nil
    if params
      action = params["action"]
      controller = params["controller"]
    end

    {
      action: action || "other",
      controller: controller || "other",
      status: status
    }
  end
end

class BMiddleware < AMiddleware
  def labels(env, result)
    super.merge(
      "foo" => "bar"
    )
  end
end
```

This would allow to simplify `lib/prometheus_exporter/server/web_collector.rb`

If you which I can refactor this MR in such way.