### PR TITLE
Add dependency on webrick

### DIFF
--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables          = ["prometheus_exporter"]
   spec.require_paths        = ["lib"]
 
+  spec.add_dependency "webrick"
+
   spec.add_development_dependency "rubocop", ">= 0.69"
   spec.add_development_dependency "bundler", ">= 2.2.2"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
As of Ruby 3.0.0, Webrick is no longer bundled with Ruby (https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/)

Adds an explicit dependency on Webrick