### PR TITLE
FEATURE: add job_name and queue_name labels to delayed job metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased
+
+- FEATURE: add job_name and queue_name labels to delayed job metrics
+
 0.7.0 - 29-12-2020
 
 - Dev: Removed support from EOL rubies, only 2.5, 2.6, 2.7 and 3.0 are supported now.

--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ end
 | Summary | `delayed_job_duration_seconds_summary`    | Summary of the time it takes jobs to execute                       | `status`   |
 | Summary | `delayed_job_attempts_summary`            | Summary of the amount of attempts it takes delayed jobs to succeed | -          |
 
+All metrics have labels for `job_name` and `queue_name`.
+
 #### Hutch Message Processing Tracer
 
 Capture [Hutch](https://github.com/gocardless/hutch) metrics (how many jobs ran? how many failed? how long did they take?)

--- a/lib/prometheus_exporter/instrumentation/delayed_job.rb
+++ b/lib/prometheus_exporter/instrumentation/delayed_job.rb
@@ -13,8 +13,8 @@ module PrometheusExporter::Instrumentation
           callbacks do |lifecycle|
             lifecycle.around(:invoke_job) do |job, *args, &block|
               max_attempts = Delayed::Worker.max_attempts
-              enqueued_count = Delayed::Job.count
-              pending_count = Delayed::Job.where(attempts: 0, locked_at: nil).count
+              enqueued_count = Delayed::Job.where(queue: job.queue).count
+              pending_count = Delayed::Job.where(attempts: 0, locked_at: nil, queue: job.queue).count
               instrumenter.call(job, max_attempts, enqueued_count, pending_count, *args, &block)
             end
           end
@@ -41,6 +41,7 @@ module PrometheusExporter::Instrumentation
       @client.send_json(
         type: "delayed_job",
         name: job.handler.to_s.match(JOB_CLASS_REGEXP).to_a[1].to_s,
+        queue_name: job.queue,
         success: success,
         duration: duration,
         attempts: attempts,

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -396,6 +396,7 @@ class PrometheusCollectorTest < Minitest::Test
 
     job = Minitest::Mock.new
     job.expect(:handler, "job_class: Class")
+    job.expect(:queue, "my_queue")
     job.expect(:attempts, 0)
 
     instrument.call(job, 20, 10, 0, nil, "default") do
@@ -404,6 +405,7 @@ class PrometheusCollectorTest < Minitest::Test
 
     failed_job = Minitest::Mock.new
     failed_job.expect(:handler, "job_class: Object")
+    failed_job.expect(:queue, "my_queue")
     failed_job.expect(:attempts, 1)
 
     begin
@@ -415,11 +417,11 @@ class PrometheusCollectorTest < Minitest::Test
 
     result = collector.prometheus_metrics_text
 
-    assert(result.include?("delayed_failed_jobs_total{job_name=\"Object\"} 1"), "has failed job")
-    assert(result.include?("delayed_jobs_total{job_name=\"Class\"} 1"), "has working job")
-    assert(result.include?("delayed_job_duration_seconds"), "has duration")
-    assert(result.include?("delayed_jobs_enqueued 10"), "has enqueued count")
-    assert(result.include?("delayed_jobs_pending 0"), "has pending count")
+    assert(result.include?("delayed_failed_jobs_total{job_name=\"Object\",queue_name=\"my_queue\"} 1"), "has failed job")
+    assert(result.include?("delayed_jobs_total{job_name=\"Class\",queue_name=\"my_queue\"} 1"), "has working job")
+    assert(result.include?("delayed_job_duration_seconds{job_name=\"Class\",queue_name=\"my_queue\"}"), "has duration")
+    assert(result.include?("delayed_jobs_enqueued{job_name=\"Class\",queue_name=\"my_queue\"} 10"), "has enqueued count")
+    assert(result.include?("delayed_jobs_pending{job_name=\"Class\",queue_name=\"my_queue\"} 0"), "has pending count")
     job.verify
     failed_job.verify
   end
@@ -432,6 +434,7 @@ class PrometheusCollectorTest < Minitest::Test
 
     job = Minitest::Mock.new
     job.expect(:handler, "job_class: Class")
+    job.expect(:queue, "my_queue")
     job.expect(:attempts, 0)
 
     instrument.call(job, 25, 10, 0, nil, "default") do
@@ -440,6 +443,7 @@ class PrometheusCollectorTest < Minitest::Test
 
     failed_job = Minitest::Mock.new
     failed_job.expect(:handler, "job_class: Object")
+    failed_job.expect(:queue, "my_queue")
     failed_job.expect(:attempts, 1)
 
     begin
@@ -451,11 +455,11 @@ class PrometheusCollectorTest < Minitest::Test
 
     result = collector.prometheus_metrics_text
 
-    assert(result.include?('delayed_failed_jobs_total{job_name="Object",service="service1"} 1'), "has failed job")
-    assert(result.include?('delayed_jobs_total{job_name="Class",service="service1"} 1'), "has working job")
-    assert(result.include?('delayed_job_duration_seconds{job_name="Class",service="service1"}'), "has duration")
-    assert(result.include?("delayed_jobs_enqueued 10"), "has enqueued count")
-    assert(result.include?("delayed_jobs_pending 0"), "has pending count")
+    assert(result.include?('delayed_failed_jobs_total{job_name="Object",queue_name="my_queue",service="service1"} 1'), "has failed job")
+    assert(result.include?('delayed_jobs_total{job_name="Class",queue_name="my_queue",service="service1"} 1'), "has working job")
+    assert(result.include?('delayed_job_duration_seconds{job_name="Class",queue_name="my_queue",service="service1"}'), "has duration")
+    assert(result.include?('delayed_jobs_enqueued{job_name="Class",queue_name="my_queue",service="service1"} 10'), "has enqueued count")
+    assert(result.include?('delayed_jobs_pending{job_name="Class",queue_name="my_queue",service="service1"} 0'), "has pending count")
     job.verify
     failed_job.verify
   end


### PR DESCRIPTION
New labels are added to the delayed job metrics.

- A `queue_name` was added for all metrics
- The existing `job_name` metrics was added for all metrics
- The `enqueued_total` and `pending_total` gauges metrics now use per queue totals

This closes https://github.com/discourse/prometheus_exporter/issues/147

Thanks @mauricepoirrier for all the help
