### PR TITLE
Fix for multiple multiple pools in ActiveRecord collector

### DIFF
--- a/lib/prometheus_exporter/server/active_record_collector.rb
+++ b/lib/prometheus_exporter/server/active_record_collector.rb
@@ -47,7 +47,8 @@ module PrometheusExporter::Server
       obj["created_at"] = now
 
       @active_record_metrics.delete_if do |current|
-        (obj["pid"] == current["pid"] && obj["hostname"] == current["hostname"]) ||
+        (obj["pid"] == current["pid"] && obj["hostname"] == current["hostname"] &&
+         obj["metric_labels"]["pool_name"] == current["metric_labels"]["pool_name"]) ||
           (current["created_at"] + MAX_ACTIVERECORD_METRIC_AGE < now)
       end
 


### PR DESCRIPTION
Use pool_name in addition to pid and hostname when deleting duplicate metrics. Fixes #166 