### PR TITLE
Add source location for MethodProfiler patches

### DIFF
--- a/lib/prometheus_exporter/instrumentation/method_profiler.rb
+++ b/lib/prometheus_exporter/instrumentation/method_profiler.rb
@@ -5,6 +5,7 @@ module PrometheusExporter::Instrumentation; end
 
 class PrometheusExporter::Instrumentation::MethodProfiler
   def self.patch(klass, methods, name)
+    patch_source_line = __LINE__ + 3
     patches = methods.map do |method_name|
       <<~RUBY
       unless defined?(#{method_name}__mp_unpatched)
@@ -26,7 +27,7 @@ class PrometheusExporter::Instrumentation::MethodProfiler
       RUBY
     end.join("\n")
 
-    klass.class_eval patches
+    klass.class_eval patches, __FILE__, patch_source_line
   end
 
   def self.transfer

--- a/test/instrumentation/method_profiler_test.rb
+++ b/test/instrumentation/method_profiler_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'prometheus_exporter/instrumentation'
+
+class PrometheusInstrumentationMethodProfilerTest < Minitest::Test
+  class SomeClass
+    def some_method
+      "Hello, world"
+    end
+  end
+
+  def setup
+    PrometheusExporter::Instrumentation::MethodProfiler.patch SomeClass, [:some_method], :test
+  end
+
+  def test_source_location
+    file, line = SomeClass.instance_method(:some_method).source_location
+    source = File.read(file).lines[line - 1].strip
+
+    assert_equal 'def #{method_name}(*args, &blk)', source
+  end
+end


### PR DESCRIPTION
I ran into [an issue with the latest version of the New Relic gem](https://github.com/newrelic/newrelic-ruby-agent/issues/659) which was caused by a bad interaction with Prometheus Exporter's method profiling on the Redis client.

It was hard to debug because I found that the source location for the `Redis::Client#call` was `(eval):3` and I had no idea where the metaprogramming that was redefining the method was happening.

This PR adds the file and line number to the `class_eval` call, so that the patched method has a useful source location.