### PR TITLE
FEATURE: always scope puma metrics on hostname in collector (#172)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Unreleased
 
 - FEATURE: add job_name and queue_name labels to delayed job metrics
+- FEATURE: always scope puma metrics on hostname in collector
 
 0.7.0 - 29-12-2020
 

--- a/lib/prometheus_exporter/instrumentation/puma.rb
+++ b/lib/prometheus_exporter/instrumentation/puma.rb
@@ -23,10 +23,17 @@ module PrometheusExporter::Instrumentation
     end
 
     def collect
-      metric = {}
-      metric[:type] = "puma"
+      metric = {
+        pid: pid,
+        type: "puma",
+        hostname: ::PrometheusExporter.hostname
+      }
       collect_puma_stats(metric)
       metric
+    end
+
+    def pid
+      @pid = ::Process.pid
     end
 
     def collect_puma_stats(metric)

--- a/lib/prometheus_exporter/server/puma_collector.rb
+++ b/lib/prometheus_exporter/server/puma_collector.rb
@@ -51,7 +51,12 @@ module PrometheusExporter::Server
       now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
 
       obj["created_at"] = now
-      @puma_metrics.delete_if { |m| m["created_at"] + MAX_PUMA_METRIC_AGE < now }
+
+      @puma_metrics.delete_if do |current|
+        (obj["pid"] == current["pid"] && obj["hostname"] == current["hostname"]) ||
+          (current["created_at"] + MAX_PUMA_METRIC_AGE < now)
+      end
+
       @puma_metrics << obj
     end
   end

--- a/test/server/puma_collector_test.rb
+++ b/test/server/puma_collector_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'mini_racer'
+require 'prometheus_exporter/server'
+require 'prometheus_exporter/instrumentation'
+
+class PrometheusPumaCollectorTest < Minitest::Test
+
+  def setup
+    PrometheusExporter::Metric::Base.default_prefix = ''
+  end
+
+  def collector
+    @collector ||= PrometheusExporter::Server::PumaCollector.new
+  end
+
+  def test_collecting_metrics_for_different_hosts_without_custom_labels
+    collector.collect(
+      "type" => "puma",
+      "pid" => "1000",
+      "hostname" => "test1.example.com",
+      "phase" => 0,
+      "workers_total" => 2,
+      "booted_workers_total" => 2,
+      "old_workers_total" => 0,
+      "request_backlog_total" => 0,
+      "running_threads_total" => 4,
+      "thread_pool_capacity_total" => 10,
+      "max_threads_total" => 10
+    )
+
+    collector.collect(
+      "type" => "puma",
+      "pid" => "1000",
+      "hostname" => "test2.example.com",
+      "phase" => 0,
+      "workers_total" => 4,
+      "booted_workers_total" => 4,
+      "old_workers_total" => 0,
+      "request_backlog_total" => 1,
+      "running_threads_total" => 9,
+      "thread_pool_capacity_total" => 10,
+      "max_threads_total" => 10
+    )
+
+    # overwriting previous metrics from first host
+    collector.collect(
+      "type" => "puma",
+      "pid" => "1000",
+      "hostname" => "test1.example.com",
+      "phase" => 0,
+      "workers_total" => 3,
+      "booted_workers_total" => 3,
+      "old_workers_total" => 0,
+      "request_backlog_total" => 2,
+      "running_threads_total" => 8,
+      "thread_pool_capacity_total" => 10,
+      "max_threads_total" => 10
+    )
+
+    metrics = collector.metrics
+    assert_equal 7, metrics.size
+    assert_equal "puma_workers_total{phase=\"0\"} 3",
+                 metrics.first.metric_text
+  end
+
+  def test_collecting_metrics_for_different_hosts_with_custom_labels
+    collector.collect(
+      "type" => "puma",
+      "pid" => "1000",
+      "hostname" => "test1.example.com",
+      "phase" => 0,
+      "workers_total" => 2,
+      "booted_workers_total" => 2,
+      "old_workers_total" => 0,
+      "request_backlog_total" => 0,
+      "running_threads_total" => 4,
+      "thread_pool_capacity_total" => 10,
+      "max_threads_total" => 10,
+      "custom_labels" => {
+        "hostname" => "test1.example.com"
+      }
+    )
+
+    collector.collect(
+      "type" => "puma",
+      "pid" => "1000",
+      "hostname" => "test2.example.com",
+      "phase" => 0,
+      "workers_total" => 4,
+      "booted_workers_total" => 4,
+      "old_workers_total" => 0,
+      "request_backlog_total" => 1,
+      "running_threads_total" => 9,
+      "thread_pool_capacity_total" => 10,
+      "max_threads_total" => 10,
+      "custom_labels" => {
+        "hostname" => "test2.example.com"
+      }
+    )
+
+    # overwriting previous metrics from first host
+    collector.collect(
+      "type" => "puma",
+      "pid" => "1000",
+      "hostname" => "test1.example.com",
+      "phase" => 0,
+      "workers_total" => 3,
+      "booted_workers_total" => 3,
+      "old_workers_total" => 0,
+      "request_backlog_total" => 2,
+      "running_threads_total" => 8,
+      "thread_pool_capacity_total" => 10,
+      "max_threads_total" => 10,
+      "custom_labels" => {
+        "hostname" => "test1.example.com"
+      }
+    )
+
+    metrics = collector.metrics
+    assert_equal 7, metrics.size
+    assert_equal "puma_workers_total{phase=\"0\",hostname=\"test2.example.com\"} 4\n" \
+                 "puma_workers_total{phase=\"0\",hostname=\"test1.example.com\"} 3",
+                 metrics.first.metric_text
+  end
+
+end


### PR DESCRIPTION
As discussed in #172, separate puma metrics by hostname and purge previous values.