### PR TITLE
FIX: ThreadError Handling

### DIFF
--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -184,6 +184,9 @@ module PrometheusExporter
           end
         end
       end
+    rescue ThreadError => e
+      raise unless e.message =~ /can't alloc thread/
+      STDERR.puts "Prometheus Exporter, failed to send message ThreadError #{e}"
     end
 
     def close_socket!


### PR DESCRIPTION
Hi @SamSaffron

We observed ThreadError was raised from prometheus_exporter when sidekiq triggers SHUTDOWN EXCEPTION.It was due to some improper shutdowns.

As per ruby ThreadError will raise only when main thread is killed then we are trying to create child thread for that main thread

```
if (GET_VM()->main_thread->status == THREAD_KILLED)
rb_raise(rb_eThreadError, "can't alloc thread");
```

So need to catch exception in Prometheus gem to handle this error.

Ref. PR: (opentelemetry-ruby) https://github.com/open-telemetry/opentelemetry-ruby/pull/607