### PR TITLE
swap from hardcoded STDERR to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To learn more see [Instrumenting Rails with Prometheus](https://samsaffron.com/a
   * [Client default host](#client-default-host)
 * [Transport concerns](#transport-concerns)
 * [JSON generation and parsing](#json-generation-and-parsing)
+* [Logging](#logging)
 * [Contributing](#contributing)
 * [License](#license)
 * [Code of Conduct](#code-of-conduct)
@@ -849,6 +850,19 @@ The `/bench` directory has simple benchmark, which is able to send through 10k m
 The `PrometheusExporter::Client` class has the method `#send-json`. This method, by default, will call `JSON.dump` on the Object it recieves. You may opt in for `oj` mode where it can use the faster `Oj.dump(obj, mode: :compat)` for JSON serialization. But be warned that if you have custom objects that implement own `to_json` methods this may not work as expected. You can opt for oj serialization with `json_serializer: :oj`.
 
 When `PrometheusExporter::Server::Collector` parses your JSON, by default it will use the faster Oj deserializer if available. This happens cause it only expects a simple Hash out of the box. You can opt in for the default JSON deserializer with `json_serializer: :json`.
+
+## Logging
+
+`PrometheusExporter::Client.default` will export to `STDERR`. To change this, you can pass your own logger:
+```ruby
+PrometheusExporter::Client.new(logger: Rails.logger)
+PrometheusExporter::Client.new(logger: Logger.new(STDOUT))
+```
+
+You can also pass a log level (default is [`Logger::WARN`](https://ruby-doc.org/stdlib-3.0.1/libdoc/logger/rdoc/Logger.html)):
+```ruby
+PrometheusExporter::Client.new(log_level: Logger::DEBUG)
+```
 
 ## Contributing
 

--- a/bin/prometheus_exporter
+++ b/bin/prometheus_exporter
@@ -3,12 +3,15 @@
 
 require 'optparse'
 require 'json'
+require 'logger'
 
 require_relative "./../lib/prometheus_exporter"
 require_relative "./../lib/prometheus_exporter/server"
 
 def run
-  options = {}
+  options = {
+    logger_path: STDERR
+  }
   custom_collector_filename = nil
   custom_type_collectors_filenames = []
 
@@ -61,15 +64,22 @@ def run
     opt.on('--unicorn-master PID_FILE', String, '(optional) PID file of unicorn master process to monitor unicorn') do |o|
       options[:unicorn_pid_file] = o
     end
+
+    opt.on('--logger-path PATH', String, '(optional) Path to file for logger output. Defaults to STDERR') do |o|
+      options[:logger_path] = o
+    end
   end.parse!
 
+  logger = Logger.new(options[:logger_path])
+  logger.level = Logger::WARN
+
   if options.has_key?(:realm) && !options.has_key?(:auth)
-    STDERR.puts "[Warn] Providing REALM without AUTH has no effect"
+    logger.warn "Providing REALM without AUTH has no effect"
   end
 
   if options.has_key?(:auth)
     unless File.exist?(options[:auth]) && File.readable?(options[:auth])
-      STDERR.puts "[Error] The AUTH file either doesn't exist or we don't have access to it"
+      logger.fatal "The AUTH file either doesn't exist or we don't have access to it"
       exit 1
     end
   end
@@ -88,7 +98,7 @@ def run
     end
 
     if !found
-      STDERR.puts "[Error] Can not find a class inheriting off PrometheusExporter::Server::CollectorBase"
+      logger.fatal "Can not find a class inheriting off PrometheusExporter::Server::CollectorBase"
       exit 1
     end
   end

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -2,6 +2,7 @@
 
 require 'socket'
 require 'thread'
+require 'logger'
 
 module PrometheusExporter
   class Client
@@ -53,14 +54,20 @@ module PrometheusExporter
     MAX_SOCKET_AGE = 25
     MAX_QUEUE_SIZE = 10_000
 
+    attr_reader :logger
+
     def initialize(
       host: ENV.fetch('PROMETHEUS_EXPORTER_HOST', 'localhost'),
       port: ENV.fetch('PROMETHEUS_EXPORTER_PORT', PrometheusExporter::DEFAULT_PORT),
       max_queue_size: nil,
       thread_sleep: 0.5,
       json_serializer: nil,
-      custom_labels: nil
+      custom_labels: nil,
+      logger: Logger.new(STDERR),
+      log_level: Logger::WARN
     )
+      @logger = logger
+      @logger.level = log_level
       @metrics = []
 
       @queue = Queue.new
@@ -125,7 +132,7 @@ module PrometheusExporter
     def send(str)
       @queue << str
       if @queue.length > @max_queue_size
-        STDERR.puts "Prometheus Exporter client is dropping message cause queue is full"
+        logger.warn "Prometheus Exporter client is dropping message cause queue is full"
         @queue.pop
       end
 
@@ -143,7 +150,7 @@ module PrometheusExporter
           @socket.write(message)
           @socket.write("\r\n")
         rescue => e
-          STDERR.puts "Prometheus Exporter is dropping a message: #{e}"
+          logger.warn "Prometheus Exporter is dropping a message: #{e}"
           @socket = nil
           raise
         end
@@ -168,7 +175,7 @@ module PrometheusExporter
       close_socket_if_old!
       process_queue
     rescue => e
-      STDERR.puts "Prometheus Exporter, failed to send message #{e}"
+      logger.error "Prometheus Exporter, failed to send message #{e}"
     end
 
     def ensure_worker_thread!
@@ -186,7 +193,7 @@ module PrometheusExporter
       end
     rescue ThreadError => e
       raise unless e.message =~ /can't alloc thread/
-      STDERR.puts "Prometheus Exporter, failed to send message ThreadError #{e}"
+      logger.error "Prometheus Exporter, failed to send message ThreadError #{e}"
     end
 
     def close_socket!

--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -79,7 +79,7 @@ module PrometheusExporter
       max_queue_size ||= MAX_QUEUE_SIZE
       max_queue_size = max_queue_size.to_i
 
-      if max_queue_size.to_i <= 0
+      if max_queue_size <= 0
         raise ArgumentError, "max_queue_size must be larger than 0"
       end
 

--- a/lib/prometheus_exporter/instrumentation/active_record.rb
+++ b/lib/prometheus_exporter/instrumentation/active_record.rb
@@ -7,11 +7,6 @@ module PrometheusExporter::Instrumentation
 
     def self.start(client: nil, frequency: 30, custom_labels: {}, config_labels: [])
 
-      config_labels.map!(&:to_sym)
-      validate_config_labels(config_labels)
-
-      active_record_collector = new(custom_labels, config_labels)
-
       client ||= PrometheusExporter::Client.default
 
       # Not all rails versions support connection pool stats
@@ -19,6 +14,11 @@ module PrometheusExporter::Instrumentation
         client.logger.error("ActiveRecord connection pool stats not supported in your rails version")
         return
       end
+
+      config_labels.map!(&:to_sym)
+      validate_config_labels(config_labels)
+
+      active_record_collector = new(custom_labels, config_labels)
 
       stop if @thread
 

--- a/lib/prometheus_exporter/instrumentation/process.rb
+++ b/lib/prometheus_exporter/instrumentation/process.rb
@@ -27,7 +27,7 @@ module PrometheusExporter::Instrumentation
             metric = process_collector.collect
             client.send_json metric
           rescue => e
-            STDERR.puts("Prometheus Exporter Failed To Collect Process Stats #{e}")
+            client.logger.error("Prometheus Exporter Failed To Collect Process Stats #{e}")
           ensure
             sleep frequency
           end

--- a/lib/prometheus_exporter/instrumentation/puma.rb
+++ b/lib/prometheus_exporter/instrumentation/puma.rb
@@ -14,7 +14,7 @@ module PrometheusExporter::Instrumentation
             metric = puma_collector.collect
             client.send_json metric
           rescue => e
-            STDERR.puts("Prometheus Exporter Failed To Collect Puma Stats #{e}")
+            client.logger.error("Prometheus Exporter Failed To Collect Puma Stats #{e}")
           ensure
             sleep frequency
           end

--- a/lib/prometheus_exporter/instrumentation/resque.rb
+++ b/lib/prometheus_exporter/instrumentation/resque.rb
@@ -11,7 +11,7 @@ module PrometheusExporter::Instrumentation
           begin
             client.send_json(resque_collector.collect)
           rescue => e
-            STDERR.puts("Prometheus Exporter Failed To Collect Resque Stats #{e}")
+            client.logger.error("Prometheus Exporter Failed To Collect Resque Stats #{e}")
           ensure
             sleep frequency
           end

--- a/lib/prometheus_exporter/instrumentation/sidekiq_queue.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq_queue.rb
@@ -11,7 +11,7 @@ module PrometheusExporter::Instrumentation
           begin
             client.send_json(sidekiq_queue_collector.collect)
           rescue StandardError => e
-            STDERR.puts("Prometheus Exporter Failed To Collect Sidekiq Queue metrics #{e}")
+            client.logger.error("Prometheus Exporter Failed To Collect Sidekiq Queue metrics #{e}")
           ensure
             sleep frequency
           end

--- a/lib/prometheus_exporter/instrumentation/unicorn.rb
+++ b/lib/prometheus_exporter/instrumentation/unicorn.rb
@@ -18,7 +18,7 @@ module PrometheusExporter::Instrumentation
             metric = unicorn_collector.collect
             client.send_json metric
           rescue StandardError => e
-            STDERR.puts("Prometheus Exporter Failed To Collect Unicorn Stats #{e}")
+            client.logger.error("Prometheus Exporter Failed To Collect Unicorn Stats #{e}")
           ensure
             sleep frequency
           end

--- a/lib/prometheus_exporter/server/runner.rb
+++ b/lib/prometheus_exporter/server/runner.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'prometheus_exporter/client'
+require_relative '../client'
 require_relative '../instrumentation/unicorn'
 
 module PrometheusExporter::Server

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -51,4 +51,17 @@ class PrometheusExporterTest < Minitest::Test
     summary_metric = client.register(:summary, 'summary_metric', 'helping', expected_quantiles)
     assert_equal(expected_quantiles, summary_metric.standard_values('value', 'key')[:opts])
   end
+
+  def test_overriding_logger
+    mock_logger = Minitest::Mock.new
+    mock_logger.expect :level=, nil, [Logger::WARN]
+    mock_logger.expect :warn, nil, ["Prometheus Exporter client is dropping message cause queue is full"]
+
+    client = PrometheusExporter::Client.new(logger: mock_logger)
+    client.instance_variable_set(:@max_queue_size, 1)
+    client.send("put a message in the queue")
+    client.send("put a second message in the queue to trigger the logger")
+
+    mock_logger.verify
+  end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -57,8 +57,7 @@ class PrometheusExporterTest < Minitest::Test
     mock_logger.expect :level=, nil, [Logger::WARN]
     mock_logger.expect :warn, nil, ["Prometheus Exporter client is dropping message cause queue is full"]
 
-    client = PrometheusExporter::Client.new(logger: mock_logger)
-    client.instance_variable_set(:@max_queue_size, 1)
+    client = PrometheusExporter::Client.new(logger: mock_logger, max_queue_size: 1)
     client.send("put a message in the queue")
     client.send("put a second message in the queue to trigger the logger")
 


### PR DESCRIPTION
logger still defaults to STDERR, so there's no change unless a user passes in their own logger

~I wasn't sure how to unit test this, doesn't seem like logger code is usually unit tested but happy to add them if you'd like!~ [`75281d3` (#177)](https://github.com/discourse/prometheus_exporter/pull/177/commits/75281d399ff2c5cd25280315d957d431e5a62cad)

I think there are three affected code paths:
1. running via `bin/prometheus_exporter`
2. including the gem in another project and initializing a client
3. running a server like https://github.com/discourse/prometheus_exporter#single-process-mode

I tested 1+2 as thoroughly as I could think of. For 3 I'm not sure how to test it other than launching the server (which works fine).

fixes https://github.com/discourse/prometheus_exporter/issues/83