### PR TITLE
Remove job labels from DelayedJob queue gauges

### DIFF
--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -19,22 +19,21 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
-      default_labels = { job_name: obj['name'], queue_name: obj['queue_name'] }
-      custom_labels = obj['custom_labels']
-
-      labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
+      custom_labels = obj['custom_labels'] || {}
+      gauge_labels = { queue_name: obj['queue_name'] }.merge(custom_labels)
+      counter_labels = gauge_labels.merge(job_name: obj['name'])
 
       ensure_delayed_job_metrics
-      @delayed_job_duration_seconds.observe(obj["duration"], labels)
-      @delayed_jobs_total.observe(1, labels)
-      @delayed_failed_jobs_total.observe(1, labels) if !obj["success"]
-      @delayed_jobs_max_attempts_reached_total.observe(1, labels) if obj["attempts"] >= obj["max_attempts"]
-      @delayed_job_duration_seconds_summary.observe(obj["duration"], labels)
-      @delayed_job_duration_seconds_summary.observe(obj["duration"], labels.merge(status: "success")) if obj["success"]
-      @delayed_job_duration_seconds_summary.observe(obj["duration"], labels.merge(status: "failed"))  if !obj["success"]
-      @delayed_job_attempts_summary.observe(obj["attempts"], labels) if obj["success"]
-      @delayed_jobs_enqueued.observe(obj["enqueued"], labels)
-      @delayed_jobs_pending.observe(obj["pending"], labels)
+      @delayed_job_duration_seconds.observe(obj["duration"], counter_labels)
+      @delayed_jobs_total.observe(1, counter_labels)
+      @delayed_failed_jobs_total.observe(1, counter_labels) if !obj["success"]
+      @delayed_jobs_max_attempts_reached_total.observe(1, counter_labels) if obj["attempts"] >= obj["max_attempts"]
+      @delayed_job_duration_seconds_summary.observe(obj["duration"], counter_labels)
+      @delayed_job_duration_seconds_summary.observe(obj["duration"], counter_labels.merge(status: "success")) if obj["success"]
+      @delayed_job_duration_seconds_summary.observe(obj["duration"], counter_labels.merge(status: "failed"))  if !obj["success"]
+      @delayed_job_attempts_summary.observe(obj["attempts"], counter_labels) if obj["success"]
+      @delayed_jobs_enqueued.observe(obj["enqueued"], gauge_labels)
+      @delayed_jobs_pending.observe(obj["pending"], gauge_labels)
     end
 
     def metrics

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -417,11 +417,11 @@ class PrometheusCollectorTest < Minitest::Test
 
     result = collector.prometheus_metrics_text
 
-    assert(result.include?("delayed_failed_jobs_total{job_name=\"Object\",queue_name=\"my_queue\"} 1"), "has failed job")
-    assert(result.include?("delayed_jobs_total{job_name=\"Class\",queue_name=\"my_queue\"} 1"), "has working job")
-    assert(result.include?("delayed_job_duration_seconds{job_name=\"Class\",queue_name=\"my_queue\"}"), "has duration")
-    assert(result.include?("delayed_jobs_enqueued{job_name=\"Class\",queue_name=\"my_queue\"} 10"), "has enqueued count")
-    assert(result.include?("delayed_jobs_pending{job_name=\"Class\",queue_name=\"my_queue\"} 0"), "has pending count")
+    assert(result.include?("delayed_failed_jobs_total{queue_name=\"my_queue\",job_name=\"Object\"} 1"), "has failed job")
+    assert(result.include?("delayed_jobs_total{queue_name=\"my_queue\",job_name=\"Class\"} 1"), "has working job")
+    assert(result.include?("delayed_job_duration_seconds{queue_name=\"my_queue\",job_name=\"Class\"}"), "has duration")
+    assert(result.include?("delayed_jobs_enqueued{queue_name=\"my_queue\"} 10"), "has enqueued count")
+    assert(result.include?("delayed_jobs_pending{queue_name=\"my_queue\"} 0"), "has pending count")
     job.verify
     failed_job.verify
   end
@@ -455,11 +455,11 @@ class PrometheusCollectorTest < Minitest::Test
 
     result = collector.prometheus_metrics_text
 
-    assert(result.include?('delayed_failed_jobs_total{job_name="Object",queue_name="my_queue",service="service1"} 1'), "has failed job")
-    assert(result.include?('delayed_jobs_total{job_name="Class",queue_name="my_queue",service="service1"} 1'), "has working job")
-    assert(result.include?('delayed_job_duration_seconds{job_name="Class",queue_name="my_queue",service="service1"}'), "has duration")
-    assert(result.include?('delayed_jobs_enqueued{job_name="Class",queue_name="my_queue",service="service1"} 10'), "has enqueued count")
-    assert(result.include?('delayed_jobs_pending{job_name="Class",queue_name="my_queue",service="service1"} 0'), "has pending count")
+    assert(result.include?('delayed_failed_jobs_total{queue_name="my_queue",service="service1",job_name="Object"} 1'), "has failed job")
+    assert(result.include?('delayed_jobs_total{queue_name="my_queue",service="service1",job_name="Class"} 1'), "has working job")
+    assert(result.include?('delayed_job_duration_seconds{queue_name="my_queue",service="service1",job_name="Class"}'), "has duration")
+    assert(result.include?('delayed_jobs_enqueued{queue_name="my_queue",service="service1"} 10'), "has enqueued count")
+    assert(result.include?('delayed_jobs_pending{queue_name="my_queue",service="service1"} 0'), "has pending count")
     job.verify
     failed_job.verify
   end


### PR DESCRIPTION
The gauges count all jobs for a queue, not just jobs of that particular class.

Resolves #180.