### PR TITLE
Fix logger for web_server

### DIFF
--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -88,7 +88,7 @@ module PrometheusExporter::Server
           @collector.process(block)
         rescue => e
           if @verbose
-            logger.error "\n\n#{e.inspect}\n#{e.backtrace}\n\n"
+            @logger.error "\n\n#{e.inspect}\n#{e.backtrace}\n\n"
           end
           @bad_metrics_total.observe
           res.body = "Bad Metrics #{e}"
@@ -106,7 +106,7 @@ module PrometheusExporter::Server
         begin
           @server.start
         rescue => e
-          logger.error "Failed to start prometheus collector web on port #{@port}: #{e}"
+          @logger.error "Failed to start prometheus collector web on port #{@port}: #{e}"
         end
       end
     end
@@ -123,7 +123,7 @@ module PrometheusExporter::Server
         end
       rescue Timeout::Error
         # we timed out ... bummer
-        logger.error "Generating Prometheus metrics text timed out"
+        @logger.error "Generating Prometheus metrics text timed out"
       end
 
       metrics = []


### PR DESCRIPTION
Hi, 

it looks like this has been broken since https://github.com/discourse/prometheus_exporter/commit/c3e26a827b59c225a2ffb34eec57d8541e6ee97f

I just noticed this when there was a silent `500` because of a [timeout](https://github.com/discourse/prometheus_exporter/blob/master/lib/prometheus_exporter/server/web_server.rb#L124) and got:

```
 ERROR NameError: undefined local variable or method `logger' for #<PrometheusExporter::Server::WebServer:0x000055f23ed4db50>\nDid you mean?  @logger
 ```