### PR TITLE
Allow collecting web metrics as histograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ class MyMiddleware < PrometheusExporter::Middleware
 end
 ```
 
+If you need to aggregate web metrics, you can switch from a summary to a histogram:
+
+```ruby
+  Rails.application.middleware.unshift PrometheusExporter::Middleware, mode: :histogram
+```
+
+In histogram mode, the same metrics will be collected but will be reported as histograms rather than summaries. This sacrifices some precision but allows aggregating web metrics across actions and nodes using [`histogram_quantile`].
+
+[`histogram_quantile`]: https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile
+
 If you're not using Rails like framework, you can extend `PrometheusExporter::Middleware#default_labels` in a way to add more relevant labels.
 For example you can mimic [prometheus-client](https://github.com/prometheus/client_ruby) labels with code like this:
 ```ruby

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To learn more see [Instrumenting Rails with Prometheus](https://samsaffron.com/a
   * [Metrics default prefix / labels](#metrics-default-prefix--labels)
   * [Client default labels](#client-default-labels)
   * [Client default host](#client-default-host)
+  * [Histogram mode](#histogram-mode)
 * [Transport concerns](#transport-concerns)
 * [JSON generation and parsing](#json-generation-and-parsing)
 * [Logging](#logging)
@@ -226,16 +227,6 @@ class MyMiddleware < PrometheusExporter::Middleware
   end
 end
 ```
-
-If you need to aggregate web metrics, you can switch from a summary to a histogram:
-
-```ruby
-  Rails.application.middleware.unshift PrometheusExporter::Middleware, mode: :histogram
-```
-
-In histogram mode, the same metrics will be collected but will be reported as histograms rather than summaries. This sacrifices some precision but allows aggregating web metrics across actions and nodes using [`histogram_quantile`].
-
-[`histogram_quantile`]: https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile
 
 If you're not using Rails like framework, you can extend `PrometheusExporter::Middleware#default_labels` in a way to add more relevant labels.
 For example you can mimic [prometheus-client](https://github.com/prometheus/client_ruby) labels with code like this:
@@ -786,6 +777,7 @@ Usage: prometheus_exporter [options]
     -c, --collector FILE             (optional) Custom collector to run
     -a, --type-collector FILE        (optional) Custom type collectors to run in main collector
     -v, --verbose
+    -g, --histogram                  Use histogram instead of summary for aggregations
         --auth FILE                  (optional) enable basic authentication using a htpasswd FILE
         --realm REALM                (optional) Use REALM for basic authentication (default: "Prometheus Exporter")
         --unicorn-listen-address ADDRESS
@@ -855,6 +847,18 @@ http_requests_total{service="app-server-01",app_name="app-01"} 1
 ### Client default host
 
 By default, `PrometheusExporter::Client.default` connects to `localhost:9394`. If your setup requires this (e.g. when using `docker-compose`), you can change the default host and port by setting the environment variables `PROMETHEUS_EXPORTER_HOST` and `PROMETHEUS_EXPORTER_PORT`.
+
+### Histogram mode
+
+By default, the built-in collectors will report aggregations as summaries. If you need to aggregate metrics across labels, you can switch from summaries to histograms:
+
+```
+$ prometheus_exporter --histogram
+```
+
+In histogram mode, the same metrics will be collected but will be reported as histograms rather than summaries. This sacrifices some precision but allows aggregating metrics across actions and nodes using [`histogram_quantile`].
+
+[`histogram_quantile`]: https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile
 
 ## Transport concerns
 

--- a/bin/prometheus_exporter
+++ b/bin/prometheus_exporter
@@ -50,6 +50,9 @@ def run
     opt.on('-v', '--verbose') do |o|
       options[:verbose] = true
     end
+    opt.on('-g', '--histogram', "Use histogram instead of summary for aggregations") do |o|
+      options[:histogram] = true
+    end
     opt.on('--auth FILE', String, "(optional) enable basic authentication using a htpasswd FILE") do |o|
       options[:auth] = o
     end

--- a/lib/prometheus_exporter/metric/base.rb
+++ b/lib/prometheus_exporter/metric/base.rb
@@ -5,6 +5,7 @@ module PrometheusExporter::Metric
 
     @default_prefix = nil if !defined?(@default_prefix)
     @default_labels = nil if !defined?(@default_labels)
+    @default_aggregation = nil if !defined?(@default_aggregation)
 
     # prefix applied to all metrics
     def self.default_prefix=(name)
@@ -21,6 +22,14 @@ module PrometheusExporter::Metric
 
     def self.default_labels
       @default_labels || {}
+    end
+
+    def self.default_aggregation=(aggregation)
+      @default_aggregation = aggregation
+    end
+
+    def self.default_aggregation
+      @default_aggregation ||= Summary
     end
 
     attr_accessor :help, :name, :data

--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -9,6 +9,7 @@ class PrometheusExporter::Middleware
   def initialize(app, config = { instrument: true, client: nil })
     @app = app
     @client = config[:client] || PrometheusExporter::Client.default
+    @mode = config.fetch(:mode, :summary)
 
     if config[:instrument]
       if defined? Redis::Client
@@ -41,7 +42,8 @@ class PrometheusExporter::Middleware
       type: "web",
       timings: info,
       queue_time: queue_time,
-      default_labels: default_labels(env, result)
+      default_labels: default_labels(env, result),
+      options: { mode: @mode }
     }
     labels = custom_labels(env)
     if labels

--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -9,7 +9,6 @@ class PrometheusExporter::Middleware
   def initialize(app, config = { instrument: true, client: nil })
     @app = app
     @client = config[:client] || PrometheusExporter::Client.default
-    @mode = config.fetch(:mode, :summary)
 
     if config[:instrument]
       if defined? Redis::Client
@@ -42,8 +41,7 @@ class PrometheusExporter::Middleware
       type: "web",
       timings: info,
       queue_time: queue_time,
-      default_labels: default_labels(env, result),
-      options: { mode: @mode }
+      default_labels: default_labels(env, result)
     }
     labels = custom_labels(env)
     if labels

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -76,12 +76,12 @@ module PrometheusExporter::Server
                 "delayed_jobs_max_attempts_reached_total", "Total number of delayed jobs that reached max attempts.")
 
         @delayed_job_duration_seconds_summary =
-            PrometheusExporter::Metric::Summary.new("delayed_job_duration_seconds_summary",
-                                                    "Summary of the time it takes jobs to execute.")
+            PrometheusExporter::Metric::Base.default_aggregation.new("delayed_job_duration_seconds_summary",
+                                                                     "Summary of the time it takes jobs to execute.")
 
         @delayed_job_attempts_summary =
-            PrometheusExporter::Metric::Summary.new("delayed_job_attempts_summary",
-                                                    "Summary of the amount of attempts it takes delayed jobs to succeed.")
+            PrometheusExporter::Metric::Base.default_aggregation.new("delayed_job_attempts_summary",
+                                                                     "Summary of the amount of attempts it takes delayed jobs to succeed.")
       end
     end
   end

--- a/lib/prometheus_exporter/server/runner.rb
+++ b/lib/prometheus_exporter/server/runner.rb
@@ -17,6 +17,7 @@ module PrometheusExporter::Server
       @prefix = nil
       @auth = nil
       @realm = nil
+      @histogram = nil
 
       options.each do |k, v|
         send("#{k}=", v) if self.class.method_defined?("#{k}=")
@@ -26,6 +27,10 @@ module PrometheusExporter::Server
     def start
       PrometheusExporter::Metric::Base.default_prefix = prefix
       PrometheusExporter::Metric::Base.default_labels = label
+
+      if histogram
+        PrometheusExporter::Metric::Base.default_aggregation = PrometheusExporter::Metric::Histogram
+      end
 
       register_type_collectors
 
@@ -47,7 +52,7 @@ module PrometheusExporter::Server
     end
 
     attr_accessor :unicorn_listen_address, :unicorn_pid_file
-    attr_writer :prefix, :port, :bind, :collector_class, :type_collectors, :timeout, :verbose, :server_class, :label, :auth, :realm
+    attr_writer :prefix, :port, :bind, :collector_class, :type_collectors, :timeout, :verbose, :server_class, :label, :auth, :realm, :histogram
 
     def auth
       @auth || nil
@@ -96,6 +101,10 @@ module PrometheusExporter::Server
 
     def label
       @label ||= PrometheusExporter::DEFAULT_LABEL
+    end
+
+    def histogram
+      @histogram || false
     end
 
     private

--- a/lib/prometheus_exporter/server/sidekiq_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_collector.rb
@@ -52,7 +52,7 @@ module PrometheusExporter::Server
       if !@sidekiq_jobs_total
 
         @sidekiq_job_duration_seconds =
-        PrometheusExporter::Metric::Summary.new(
+        PrometheusExporter::Metric::Base.default_aggregation.new(
           "sidekiq_job_duration_seconds", "Total time spent in sidekiq jobs.")
 
         @sidekiq_jobs_total =

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -4,7 +4,6 @@ module PrometheusExporter::Server
   class WebCollector < TypeCollector
     def initialize
       @metrics = {}
-      @aggregation = PrometheusExporter::Metric::Summary
       @http_requests_total = nil
       @http_duration_seconds = nil
       @http_redis_duration_seconds = nil
@@ -17,7 +16,6 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
-      parse_options(obj)
       ensure_metrics
       observe(obj)
     end
@@ -35,22 +33,22 @@ module PrometheusExporter::Server
           "Total HTTP requests from web app."
         )
 
-        @metrics["http_duration_seconds"] = @http_duration_seconds = @aggregation.new(
+        @metrics["http_duration_seconds"] = @http_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
           "http_duration_seconds",
           "Time spent in HTTP reqs in seconds."
         )
 
-        @metrics["http_redis_duration_seconds"] = @http_redis_duration_seconds = @aggregation.new(
+        @metrics["http_redis_duration_seconds"] = @http_redis_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
           "http_redis_duration_seconds",
           "Time spent in HTTP reqs in Redis, in seconds."
         )
 
-        @metrics["http_sql_duration_seconds"] = @http_sql_duration_seconds = @aggregation.new(
+        @metrics["http_sql_duration_seconds"] = @http_sql_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
           "http_sql_duration_seconds",
           "Time spent in HTTP reqs in SQL in seconds."
         )
 
-        @metrics["http_queue_duration_seconds"] = @http_queue_duration_seconds = @aggregation.new(
+        @metrics["http_queue_duration_seconds"] = @http_queue_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
           "http_queue_duration_seconds",
           "Time spent queueing the request in load balancer in seconds."
         )
@@ -75,12 +73,6 @@ module PrometheusExporter::Server
       end
       if queue_time = obj["queue_time"]
         @http_queue_duration_seconds.observe(queue_time, labels)
-      end
-    end
-
-    def parse_options(obj)
-      if obj.key?('options') && obj['options']['mode'] == 'histogram'
-        @aggregation = PrometheusExporter::Metric::Histogram
       end
     end
   end

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -4,6 +4,7 @@ module PrometheusExporter::Server
   class WebCollector < TypeCollector
     def initialize
       @metrics = {}
+      @aggregation = PrometheusExporter::Metric::Summary
       @http_requests_total = nil
       @http_duration_seconds = nil
       @http_redis_duration_seconds = nil
@@ -16,6 +17,7 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
+      parse_options(obj)
       ensure_metrics
       observe(obj)
     end
@@ -33,22 +35,22 @@ module PrometheusExporter::Server
           "Total HTTP requests from web app."
         )
 
-        @metrics["http_duration_seconds"] = @http_duration_seconds = PrometheusExporter::Metric::Summary.new(
+        @metrics["http_duration_seconds"] = @http_duration_seconds = @aggregation.new(
           "http_duration_seconds",
           "Time spent in HTTP reqs in seconds."
         )
 
-        @metrics["http_redis_duration_seconds"] = @http_redis_duration_seconds = PrometheusExporter::Metric::Summary.new(
+        @metrics["http_redis_duration_seconds"] = @http_redis_duration_seconds = @aggregation.new(
           "http_redis_duration_seconds",
           "Time spent in HTTP reqs in Redis, in seconds."
         )
 
-        @metrics["http_sql_duration_seconds"] = @http_sql_duration_seconds = PrometheusExporter::Metric::Summary.new(
+        @metrics["http_sql_duration_seconds"] = @http_sql_duration_seconds = @aggregation.new(
           "http_sql_duration_seconds",
           "Time spent in HTTP reqs in SQL in seconds."
         )
 
-        @metrics["http_queue_duration_seconds"] = @http_queue_duration_seconds = PrometheusExporter::Metric::Summary.new(
+        @metrics["http_queue_duration_seconds"] = @http_queue_duration_seconds = @aggregation.new(
           "http_queue_duration_seconds",
           "Time spent queueing the request in load balancer in seconds."
         )
@@ -73,6 +75,12 @@ module PrometheusExporter::Server
       end
       if queue_time = obj["queue_time"]
         @http_queue_duration_seconds.observe(queue_time, labels)
+      end
+    end
+
+    def parse_options(obj)
+      if obj.key?('options') && obj['options']['mode'] == 'histogram'
+        @aggregation = PrometheusExporter::Metric::Histogram
       end
     end
   end

--- a/test/metric/base_test.rb
+++ b/test/metric/base_test.rb
@@ -17,6 +17,7 @@ module PrometheusExporter::Metric
 
     after do
       Base.default_prefix = ''
+      Base.default_labels = {}
       Base.default_aggregation = nil
     end
 

--- a/test/metric/base_test.rb
+++ b/test/metric/base_test.rb
@@ -12,11 +12,12 @@ module PrometheusExporter::Metric
     before  do
       Base.default_prefix = ''
       Base.default_labels = {}
+      Base.default_aggregation = nil
     end
 
     after do
       Base.default_prefix = ''
-      Base.default_labels = {}
+      Base.default_aggregation = nil
     end
 
     it "supports a dynamic prefix" do
@@ -110,6 +111,29 @@ module PrometheusExporter::Metric
       TEXT
 
       assert_equal(summary.to_prometheus_text.strip, text.strip)
+    end
+
+    it "creates a summary by default" do
+      aggregation = Base.default_aggregation.new("test", "test")
+
+      text = <<~TEXT
+        # HELP test test
+        # TYPE test summary
+      TEXT
+
+      assert_equal(aggregation.to_prometheus_text.strip, text.strip)
+    end
+
+    it "creates a histogram when configured" do
+      Base.default_aggregation = Histogram
+      aggregation = Base.default_aggregation.new("test", "test")
+
+      text = <<~TEXT
+        # HELP test test
+        # TYPE test histogram
+      TEXT
+
+      assert_equal(aggregation.to_prometheus_text.strip, text.strip)
     end
   end
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -89,13 +89,4 @@ class PrometheusExporterMiddlewareTest < Minitest::Test
     assert_invalid_headers_response
   end
 
-  def test_collecting_metrics_in_histogram_mode
-    configure_middleware(mode: :histogram)
-    get '/'
-    assert last_response.ok?
-    refute_nil client.last_send
-    refute_nil client.last_send[:options]
-    assert_equal :histogram, client.last_send[:options][:mode]
-  end
-
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -31,7 +31,7 @@ class PrometheusExporterMiddlewareTest < Minitest::Test
     @now = Process.clock_gettime(Process::CLOCK_REALTIME)
   end
 
-  def configure_middleware(overrides={})
+  def configure_middleware(overrides = {})
     config = { client: client, instrument: true }.merge(overrides)
     @app = PrometheusExporter::Middleware.new(inner_app, config)
     def @app.request_start

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -7,6 +7,8 @@ require 'prometheus_exporter/middleware'
 class PrometheusExporterMiddlewareTest < Minitest::Test
   include Rack::Test::Methods
 
+  attr_reader :app
+
   class FakeClient
     attr_reader :last_send
 
@@ -29,17 +31,16 @@ class PrometheusExporterMiddlewareTest < Minitest::Test
     @now = Process.clock_gettime(Process::CLOCK_REALTIME)
   end
 
-  def app
-    @middleware ||= begin
-      app = PrometheusExporter::Middleware.new(inner_app, client: client, instrument: true)
-      def app.request_start
-        1234567891.123
-      end
-      app
+  def configure_middleware(overrides={})
+    config = { client: client, instrument: true }.merge(overrides)
+    @app = PrometheusExporter::Middleware.new(inner_app, config)
+    def @app.request_start
+      1234567891.123
     end
   end
 
   def assert_valid_headers_response(delta = 0.5)
+    configure_middleware
     get '/'
     assert last_response.ok?
     refute_nil client.last_send
@@ -48,6 +49,7 @@ class PrometheusExporterMiddlewareTest < Minitest::Test
   end
 
   def assert_invalid_headers_response
+    configure_middleware
     get '/'
     assert last_response.ok?
     refute_nil client.last_send
@@ -55,31 +57,45 @@ class PrometheusExporterMiddlewareTest < Minitest::Test
   end
 
   def test_converting_apache_request_start
+    configure_middleware
     now_microsec = '1234567890123456'
     header 'X-Request-Start', "t=#{now_microsec}"
     assert_valid_headers_response
   end
 
   def test_converting_nginx_request_start
+    configure_middleware
     now = '1234567890.123'
     header 'X-Request-Start', "t=#{now}"
     assert_valid_headers_response
   end
 
   def test_request_start_in_wrong_format
+    configure_middleware
     header 'X-Request-Start', ""
     assert_invalid_headers_response
   end
 
   def test_converting_amzn_trace_id_start
+    configure_middleware
     now = '1234567890'
     header 'X-Amzn-Trace-Id', "Root=1-#{now.to_i.to_s(16)}-abc123"
     assert_valid_headers_response
   end
 
   def test_amzn_trace_id_in_wrong_format
+    configure_middleware
     header 'X-Amzn-Trace-Id', ""
     assert_invalid_headers_response
+  end
+
+  def test_collecting_metrics_in_histogram_mode
+    configure_middleware(mode: :histogram)
+    get '/'
+    assert last_response.ok?
+    refute_nil client.last_send
+    refute_nil client.last_send[:options]
+    assert_equal :histogram, client.last_send[:options][:mode]
   end
 
 end

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -564,7 +564,6 @@ class PrometheusCollectorTest < Minitest::Test
     job.verify
   end
 
-
   require 'minitest/stub_const'
 
   def test_it_can_collect_puma_metrics

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -10,6 +10,11 @@ class PrometheusCollectorTest < Minitest::Test
 
   def setup
     PrometheusExporter::Metric::Base.default_prefix = ''
+    PrometheusExporter::Metric::Base.default_aggregation = nil
+  end
+
+  def teardown
+    PrometheusExporter::Metric::Base.default_aggregation = nil
   end
 
   class PipedClient
@@ -369,6 +374,29 @@ class PrometheusCollectorTest < Minitest::Test
     mock_sidekiq_que.verify
   end
 
+  def test_it_can_collect_sidekiq_metrics_in_histogram_mode
+    PrometheusExporter::Metric::Base.default_aggregation = PrometheusExporter::Metric::Histogram
+    collector = PrometheusExporter::Server::Collector.new
+    client = PipedClient.new(collector)
+
+    instrument = PrometheusExporter::Instrumentation::Sidekiq.new(client: client)
+
+    instrument.call("hello", nil, "default") do
+      # nothing
+    end
+
+    begin
+      instrument.call(false, nil, "default") do
+        boom
+      end
+    rescue
+    end
+
+    result = collector.prometheus_metrics_text
+
+    assert_includes(result, "sidekiq_job_duration_seconds histogram")
+  end
+
   def test_it_can_collect_shoryuken_metrics_with_custom_lables
     collector = PrometheusExporter::Server::Collector.new
     client = PipedClient.new(collector, custom_labels: { service: 'service1' })
@@ -512,6 +540,30 @@ class PrometheusCollectorTest < Minitest::Test
     job.verify
     failed_job.verify
   end
+
+  def test_it_can_collect_delayed_job_metrics_in_histogram_mode
+    PrometheusExporter::Metric::Base.default_aggregation = PrometheusExporter::Metric::Histogram
+    collector = PrometheusExporter::Server::Collector.new
+    client = PipedClient.new(collector)
+
+    instrument = PrometheusExporter::Instrumentation::DelayedJob.new(client: client)
+
+    job = Minitest::Mock.new
+    job.expect(:handler, "job_class: Class")
+    job.expect(:queue, "my_queue")
+    job.expect(:attempts, 0)
+
+    instrument.call(job, 20, 10, 0, nil, "default") do
+      # nothing
+    end
+
+    result = collector.prometheus_metrics_text
+
+    assert_includes(result, "delayed_job_duration_seconds_summary histogram")
+    assert_includes(result, "delayed_job_attempts_summary histogram")
+    job.verify
+  end
+
 
   require 'minitest/stub_const'
 

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -6,6 +6,10 @@ require 'prometheus_exporter/server'
 require 'prometheus_exporter/instrumentation'
 
 class PrometheusWebCollectorTest < Minitest::Test
+  def setup
+    PrometheusExporter::Metric::Base.default_prefix = ''
+  end
+
   def collector
     @collector ||= PrometheusExporter::Server::WebCollector.new
   end

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -8,6 +8,11 @@ require 'prometheus_exporter/instrumentation'
 class PrometheusWebCollectorTest < Minitest::Test
   def setup
     PrometheusExporter::Metric::Base.default_prefix = ''
+    PrometheusExporter::Metric::Base.default_aggregation = nil
+  end
+
+  def teardown
+    PrometheusExporter::Metric::Base.default_aggregation = nil
   end
 
   def collector
@@ -77,6 +82,8 @@ class PrometheusWebCollectorTest < Minitest::Test
   end
 
   def test_collecting_metrics_in_histogram_mode
+    PrometheusExporter::Metric::Base.default_aggregation = PrometheusExporter::Metric::Histogram
+
     collector.collect(
       'type' => 'web',
       "timings" => {
@@ -90,9 +97,6 @@ class PrometheusWebCollectorTest < Minitest::Test
         },
         "queue" => 0.03,
         "total_duration" => 1.0
-      },
-      'options' => {
-        'mode' => 'histogram',
       },
       'default_labels' => {
         'controller' => 'home',

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -71,4 +71,38 @@ class PrometheusWebCollectorTest < Minitest::Test
     assert_equal 5, metrics.size
     assert(metrics.first.metric_text.include?('http_requests_total{controller="home",action="index",status="200",service="service1"}'))
   end
+
+  def test_collecting_metrics_in_histogram_mode
+    collector.collect(
+      'type' => 'web',
+      "timings" => {
+        "sql" => {
+          duration: 0.5,
+          count: 40
+        },
+        "redis" => {
+          duration: 0.03,
+          count: 4
+        },
+        "queue" => 0.03,
+        "total_duration" => 1.0
+      },
+      'options' => {
+        'mode' => 'histogram',
+      },
+      'default_labels' => {
+        'controller' => 'home',
+        'action' => 'index',
+        'status' => 200,
+      },
+      'custom_labels' => {
+        'service' => 'service1'
+      }
+    )
+
+    metrics = collector.metrics
+
+    assert_equal 5, metrics.size
+    assert_includes(metrics.map(&:metric_text).flat_map(&:lines), "http_duration_seconds_bucket{controller=\"home\",action=\"index\",status=\"200\",service=\"service1\",le=\"+Inf\"} 1\n")
+  end
 end


### PR DESCRIPTION
Web metrics are currently reported as summaries, which provides precise
data for each controller, action, and node. However, timings from
low-throughput actions will cause an average to be wildly inaccurate,
which means aggregating across controllers, actions, and nodes is not
currently possible.

This adds an option to the middleware which instructs the collector to
use histogram metrics rather than summaries, which allows estimating
aggregates using histogram_quantile.

Resolves #92.
