### PR TITLE
Add back username and port as AR configuration values

### DIFF
--- a/lib/prometheus_exporter/instrumentation/active_record.rb
+++ b/lib/prometheus_exporter/instrumentation/active_record.rb
@@ -87,7 +87,7 @@ module PrometheusExporter::Instrumentation
           .map { |k, v| [k.to_s.dup.prepend("dbconfig_"), v] }.to_h)
       else
         @metric_labels.merge(pool_name: pool.db_config.name).merge(
-          @config_labels.each_with_object({}) { |l, acc| acc["dbconfig_#{l}"] = pool.db_config.public_send(l) })
+          @config_labels.each_with_object({}) { |l, acc| acc["dbconfig_#{l}"] = pool.db_config.configuration_hash[l.to_sym] })
       end
     end
   end


### PR DESCRIPTION
In Rail 6.1 the information return is from an `ActiveRecord::DatabaseConfigurations::HashConfig` object, with methods for some but not all of the configuration attributes. This fixes a bug wheree `database` and `host` had getter methods, but the `username` and `port` values did not. All values are now just fetched from the instance variable configuration_hash directly.

This fixes #187