### PR TITLE
FEATURE: SidekiqQueue - allow exposing all queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ Sidekiq.configure_server do |config|
 end
 ```
 
+This will only monitor the queues that are consumed by the sidekiq process you are on.  You can pass an `all_queues` parameter to monitor metrics on all queues.
+
 To monitor Sidekiq process info:
 
 ```ruby


### PR DESCRIPTION
Hi! I added the the Sidekiq Queue instrumentation back in https://github.com/discourse/prometheus_exporter/pull/114 and when trying to upgrade this gem on our apps I found https://github.com/discourse/prometheus_exporter/pull/126, which breaks our setup. We'd really prefer it if we could get metrics on all queues, not just the ones from the current process.

In case it's relevant, we run a single-replica pod that exposes this and other kinds of metrics that don't belong to a specific pod. We like this a bit better, it avoids having the same metric (queue latency is a "global" metric, not specific to any pod) exposed by multiple targets.

This PR keeps the existing default, with the `all_queues` option enabling the desired behavior.

We'd appreciate if this was considered for incorporation 😄 