### PR TITLE
fix dead:false ignored in sidekiq death handler

### DIFF
--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -13,7 +13,7 @@ module PrometheusExporter::Instrumentation
   class Sidekiq
     def self.death_handler
       -> (job, ex) do
-        job_is_fire_and_forget = job["retry"] == false
+        job_is_fire_and_forget = job["dead"] == false || job["retry"] == false
 
         unless job_is_fire_and_forget
           PrometheusExporter::Client.default.send_json(


### PR DESCRIPTION
You can prevent a sidekiq job form going into the dead-set by either setting `dead: false` or by setting `retry: false` ([wiki](https://github.com/mperham/sidekiq/wiki/Error-Handling#dead-set)). 

It seems like the `dead: false` option was overlooked in #76 😅 
