### PR TITLE
FEATURE: Add labels to preflight CORS requests

### DIFF
--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -54,10 +54,18 @@ class PrometheusExporter::Middleware
   def default_labels(env, result)
     status = (result && result[0]) || -1
     params = env["action_dispatch.request.parameters"]
+    cors = env["rack.cors"]
     action = controller = nil
     if params
       action = params["action"]
       controller = params["controller"]
+    elsif cors && cors.respond_to?(:preflight?) && cors.preflight?
+      # if the Rack CORS Middleware identifies the request as a preflight request,
+      # the stack doesn't get to the point where controllers/actions are defined
+      action = "preflight"
+      controller = "preflight"
+    end
+
     end
 
     {


### PR DESCRIPTION
Adds support for [rack-cors gem](https://github.com/cyu/rack-cors), so that Preflight requests don't get labeled as `controller="other"` and `action="other"` and instead get `controller="preflight"` and `action="/my/path"`.