### PR TITLE
feat(histogram): buckets

### DIFF
--- a/lib/prometheus_exporter/metric/histogram.rb
+++ b/lib/prometheus_exporter/metric/histogram.rb
@@ -5,6 +5,16 @@ module PrometheusExporter::Metric
 
     DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5.0, 10.0].freeze
 
+    @default_buckets = nil if !defined?(@default_buckets)
+
+    def self.default_buckets
+      @default_buckets || DEFAULT_BUCKETS
+    end
+
+    def self.default_buckets=(buckets)
+      @default_buckets = buckets
+    end
+
     def initialize(name, help, opts = {})
       super(name, help)
       @buckets = (opts[:buckets] || DEFAULT_BUCKETS).sort.reverse

--- a/test/metric/histogram_test.rb
+++ b/test/metric/histogram_test.rb
@@ -139,5 +139,19 @@ module PrometheusExporter::Metric
 
       assert_equal(histogram.to_h, { name: "bob", family: "skywalker" } => { "count" => 3, "sum" => 1.79 })
     end
+
+    it 'supports default buckets' do
+      assert_equal(Histogram::DEFAULT_BUCKETS, [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5.0, 10.0])
+      assert_equal(Histogram::DEFAULT_BUCKETS, Histogram.default_buckets)
+    end
+
+    it 'allows to change default buckets' do
+      custom_buckets = [0.005, 0.1, 1, 2, 5, 10]
+      Histogram.default_buckets = custom_buckets
+
+      assert_equal(Histogram.default_buckets, custom_buckets)
+
+      Histogram.default_buckets = Histogram::DEFAULT_BUCKETS
+    end
   end
 end


### PR DESCRIPTION
## What?

Allow to specify values for default buckets in histogram.

## Why?
Would be good to have ability to specify your own values for buckets. There is a similar ability for labels. 