### PR TITLE
Add per worker custom labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # weekly
+    - cron: "0 0 * * 0" # weekly
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, "3.0", 3.1]
         activerecord: [60, 61]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -421,6 +421,18 @@ Sometimes the Sidekiq server shuts down before it can send metrics, that were ge
   end
 ```
 
+Custom labels can be added for individual jobs by defining a class method on the job class. These labels will be added to all Sidekiq metrics written by the job:
+
+```ruby
+  class WorkerWithCustomLabels
+    def self.custom_labels
+      { my_label: 'value-here', other_label: 'second-val' }
+    end
+
+    def perform; end
+  end
+```
+
 ##### Metrics collected by Sidekiq Instrumentation
 
 **PrometheusExporter::Instrumentation::Sidekiq**

--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -88,7 +88,7 @@ module PrometheusExporter::Instrumentation
         else
           "#{target.class.name}##{method_name}"
         end
-      rescue Psych::DisallowedClass => e
+      rescue Psych::DisallowedClass, ArgumentError
         parsed = Psych.parse(msg['args'].first)
         children = parsed.root.children
         target = (children[0].value || children[0].tag).sub('!', '')
@@ -100,7 +100,7 @@ module PrometheusExporter::Instrumentation
           class_name
         end
       end
-    rescue Exception => e
+    rescue
       class_name
     end
   end

--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -63,13 +63,10 @@ module PrometheusExporter::Instrumentation
     private
 
     def get_name(worker, msg)
-      puts "get name:"
       class_name = worker.class.to_s
       if class_name == JOB_WRAPPER_CLASS_NAME
-        puts "is a wrapper class"
         get_job_wrapper_name(msg)
       elsif DELAYED_CLASS_NAMES.include?(class_name)
-        puts "is a delayed class"
         get_delayed_name(msg, class_name)
       else
         class_name
@@ -77,7 +74,6 @@ module PrometheusExporter::Instrumentation
     end
 
     def get_job_wrapper_name(msg)
-      puts "class name: #{msg['wrapped']}"
       msg['wrapped']
     end
 

--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -15,14 +15,22 @@ module PrometheusExporter::Instrumentation
       -> (job, ex) do
         job_is_fire_and_forget = job["retry"] == false
 
+        worker_class = Object.const_get(job["class"])
+        worker_custom_labels = self.get_worker_custom_labels(worker_class)
+
         unless job_is_fire_and_forget
           PrometheusExporter::Client.default.send_json(
             type: "sidekiq",
             name: job["class"],
             dead: true,
+            custom_labels: worker_custom_labels
           )
         end
       end
+    end
+
+    def self.get_worker_custom_labels(worker_class)
+      worker_class.respond_to?(:custom_labels) ? worker_class.custom_labels : {}
     end
 
     def initialize(client: nil)
@@ -47,7 +55,8 @@ module PrometheusExporter::Instrumentation
         queue: queue,
         success: success,
         shutdown: shutdown,
-        duration: duration
+        duration: duration,
+        custom_labels: self.class.get_worker_custom_labels(worker.class)
       )
     end
 

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -29,6 +29,14 @@ class PrometheusCollectorTest < Minitest::Test
     end
   end
 
+  class WorkerWithCustomLabels
+    def self.custom_labels
+      { test_label: 'one', other_label: 'two' }
+    end
+
+    def perform; end
+  end
+
   def test_local_metric
     collector = PrometheusExporter::Server::Collector.new
     client = PrometheusExporter::LocalClient.new(collector: collector)
@@ -323,6 +331,100 @@ class PrometheusCollectorTest < Minitest::Test
     assert(result.include?('sidekiq_jobs_total{job_name="String#foo",queue="default",service="service1"} 1'), "has sidekiq delayed class")
     assert(result.include?('sidekiq_jobs_total{job_name="Object#foo",queue="default",service="service1"} 1'), "has sidekiq delayed class")
     assert(result.include?('sidekiq_jobs_total{job_name="Sidekiq::Extensions::DelayedClass",queue="default",service="service1"} 1'), "has sidekiq delayed class")
+  end
+
+  def test_it_can_collect_sidekiq_metrics_with_custom_labels_from_worker_class
+    worker_class = 'WorkerWithCustomLabels'
+    msg = { 'wrapped' => worker_class }
+    queue = "default"
+
+    client = Minitest::Mock.new
+    client.expect(:send_json, '', [{
+      type: "sidekiq",
+      name: "PrometheusCollectorTest::#{worker_class}",
+      queue: queue,
+      success: true,
+      shutdown: false,
+      duration: 0,
+      custom_labels: WorkerWithCustomLabels.custom_labels
+    }])
+
+    ::Process.stub(:clock_gettime, 1, ::Process::CLOCK_MONOTONIC) do
+      instrument = PrometheusExporter::Instrumentation::Sidekiq.new(client: client)
+      collector = PrometheusExporter::Server::Collector.new
+      instrument.call(WorkerWithCustomLabels.new, msg, queue) {}
+      collector.prometheus_metrics_text
+    end
+
+    assert_mock client
+  end
+
+  def test_it_can_collect_sidekiq_metrics_on_job_death
+    job = {
+      "dead" => true,
+      "retry" => true,
+      "class" => "TestWorker"
+    }
+
+    worker = Minitest::Mock.new
+
+    client = Minitest::Mock.new
+    client.expect(:send_json, '', [{
+      type: "sidekiq",
+      name: job["class"],
+      dead: true,
+      custom_labels: {}
+    }])
+
+    Object.stub(:const_get, worker, [job['class']]) do
+      PrometheusExporter::Client.stub(:default, client) do
+        PrometheusExporter::Instrumentation::Sidekiq.death_handler.call(job, RuntimeError.new('bang'))
+      end
+    end
+
+    assert_mock client
+    assert_mock worker
+  end
+
+  def test_it_can_collect_sidekiq_metrics_on_job_death_with_custom_labels_from_worker_class
+    job = {
+      "dead" => true,
+      "retry" => true,
+      "class" => "WorkerWithCustomLabels"
+    }
+
+    client = Minitest::Mock.new
+    client.expect(:send_json, '', [{
+      type: "sidekiq",
+      name: job["class"],
+      dead: true,
+      custom_labels: WorkerWithCustomLabels.custom_labels
+    }])
+
+    Object.stub(:const_get, WorkerWithCustomLabels, [job['class']]) do
+      PrometheusExporter::Client.stub(:default, client) do
+        PrometheusExporter::Instrumentation::Sidekiq.death_handler.call(job, RuntimeError.new('bang'))
+      end
+    end
+
+    assert_mock client
+  end
+
+  def test_it_does_not_collect_sidekiq_metrics_on_fire_forget_job_death
+    job = {
+      "dead" => false,
+      "retry" => false,
+      "class" => "WorkerWithCustomLabels"
+    }
+    custom_labels = { from_worker: 'test1' }
+
+    client = Minitest::Mock.new
+
+    Object.stub(:const_get, WorkerWithCustomLabels, [job['class']]) do
+      PrometheusExporter::Client.stub(:default, client) do
+        PrometheusExporter::Instrumentation::Sidekiq.death_handler.call(job, RuntimeError.new('bang'))
+      end
+    end
   end
 
   def test_it_can_collect_sidekiq_queue_metrics_for_all_queues


### PR DESCRIPTION
This adds the ability for sidekiq worker classes to have a self.custom_labels field which lets them set custom labels to be attached to metrics they export. This makes it easier to alerts based on the metrics for specific workers or groups of workers