### PR TITLE
FIX: stop raising NoMethodError when processing unregistered types

### DIFF
--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -38,10 +38,8 @@ module PrometheusExporter::Server
         if collector = @collectors[obj["type"]]
           collector.collect(obj)
         else
-          metric = @metrics[obj["name"]]
-          if !metric
-            metric = register_metric_unsafe(obj)
-          end
+          metric = @metrics[obj["name"]] || register_metric_unsafe(obj) or
+            return
 
           keys = obj["keys"] || {}
           if obj["custom_labels"]

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -242,6 +242,14 @@ class PrometheusCollectorTest < Minitest::Test
     assert_equal(text, collector.prometheus_metrics_text)
   end
 
+  def test_it_does_not_raise_on_fail_to_register
+    collector = PrometheusExporter::Server::Collector.new
+    json = {
+      type: :something_with_no_registered_collector
+    }.to_json
+    collector.process(json) # Should not raise an exception; previously raised NoMethodError
+  end
+
   def test_it_can_collect_sidekiq_metrics
     collector = PrometheusExporter::Server::Collector.new
     client = PipedClient.new(collector)


### PR DESCRIPTION
We've found a lot of log noise comes from `PrometheusExporter::Server::Collector#process_hash` whenever `#register_metric_unsafe` returns `nil`. We recognise there are two problems there;

1. Our collectors aren't registering properly. We're working on this.
2. There's dissonance between the two aforementioned functions, with one not being prepared for the other to return nil.

This PR suggests a remedy for the latter.

It also raises the broader question of how this scenario could be better handled, since we've somewhat clumsily managed to demonstrate that it can occur in production code. A quick search shows 5 usages of `STDERR.puts`, which would ideally be handleable somehow. Some ideas would be;

- Use exceptions to propagate errors up to the web server, and log them; or
- Drill the web server's logger down to the objects most local to the errors.
- Rescue exceptions in the server's main `mount_proc` block and send 500s or similar back. I'm not sure what the client repercussions would be there.

I'm happy to discuss options and draft alternate PRs if this one isn't the way we want to go. Someone else in my organisation did our Prometheus implementations, so I'm pretty unfamiliar with its ecosystem and with this gem, and I'm happy to be corrected if I've missed anything.

Thanks everyone!