### PR TITLE
Rename metric http_duration_seconds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased
+
+- BREAKING: rename all `http_duration` metrics to `http_request_duration` to match prometheus official naming conventions (See https://prometheus.io/docs/practices/naming/#metric-names).
+
 1.0.1 - 2021-12-22
 
 - FEATURE: add labels to preflight requests

--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ $ bundle exec prometheus_exporter
 
 #### Metrics collected by Rails integration middleware
 
-| Type    | Name                            | Description                                                 |
-| ---     | ---                             | ---                                                         |
-| Counter | `http_requests_total`           | Total HTTP requests from web app                            |
-| Summary | `http_duration_seconds`         | Time spent in HTTP reqs in seconds                          |
-| Summary | `http_redis_duration_seconds`¹  | Time spent in HTTP reqs in Redis, in seconds                |
-| Summary | `http_sql_duration_seconds`²    | Time spent in HTTP reqs in SQL in seconds                   |
-| Summary | `http_queue_duration_seconds`³  | Time spent queueing the request in load balancer in seconds |
+| Type    | Name                                   | Description                                                 |
+| ---     | ---                                    | ---                                                         |
+| Counter | `http_requests_total`                  | Total HTTP requests from web app                            |
+| Summary | `http_request_duration_seconds`        | Time spent in HTTP reqs in seconds                          |
+| Summary | `http_request_redis_duration_seconds`¹ | Time spent in HTTP reqs in Redis, in seconds                |
+| Summary | `http_request_sql_duration_seconds`²   | Time spent in HTTP reqs in SQL in seconds                   |
+| Summary | `http_request_queue_duration_seconds`³ | Time spent queueing the request in load balancer in seconds |
 
 All metrics have a `controller` and an `action` label.
 `http_requests_total` additionally has a (HTTP response) `status` label.
@@ -251,7 +251,7 @@ end
 ```
 That way you won't have all metrics labeled with `controller=other` and `action=other`, but have labels such as
 ```
-ruby_http_duration_seconds{path="/api/v1/teams/:id",method="GET",status="200",quantile="0.99"} 0.009880661998977303
+ruby_http_request_duration_seconds{path="/api/v1/teams/:id",method="GET",status="200",quantile="0.99"} 0.009880661998977303
 ```
 
 ¹) Only available when Redis is used.

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -5,10 +5,10 @@ module PrometheusExporter::Server
     def initialize
       @metrics = {}
       @http_requests_total = nil
-      @http_duration_seconds = nil
-      @http_redis_duration_seconds = nil
-      @http_sql_duration_seconds = nil
-      @http_queue_duration_seconds = nil
+      @http_request_duration_seconds = nil
+      @http_request_redis_duration_seconds = nil
+      @http_request_sql_duration_seconds = nil
+      @http_request_queue_duration_seconds = nil
     end
 
     def type
@@ -33,23 +33,23 @@ module PrometheusExporter::Server
           "Total HTTP requests from web app."
         )
 
-        @metrics["http_duration_seconds"] = @http_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
-          "http_duration_seconds",
+        @metrics["http_request_duration_seconds"] = @http_request_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
+          "http_request_duration_seconds",
           "Time spent in HTTP reqs in seconds."
         )
 
-        @metrics["http_redis_duration_seconds"] = @http_redis_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
-          "http_redis_duration_seconds",
+        @metrics["http_request_redis_duration_seconds"] = @http_request_redis_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
+          "http_request_redis_duration_seconds",
           "Time spent in HTTP reqs in Redis, in seconds."
         )
 
-        @metrics["http_sql_duration_seconds"] = @http_sql_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
-          "http_sql_duration_seconds",
+        @metrics["http_request_sql_duration_seconds"] = @http_request_sql_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
+          "http_request_sql_duration_seconds",
           "Time spent in HTTP reqs in SQL in seconds."
         )
 
-        @metrics["http_queue_duration_seconds"] = @http_queue_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
-          "http_queue_duration_seconds",
+        @metrics["http_request_queue_duration_seconds"] = @http_request_queue_duration_seconds = PrometheusExporter::Metric::Base.default_aggregation.new(
+          "http_request_queue_duration_seconds",
           "Time spent queueing the request in load balancer in seconds."
         )
       end
@@ -63,16 +63,16 @@ module PrometheusExporter::Server
       @http_requests_total.observe(1, labels)
 
       if timings = obj["timings"]
-        @http_duration_seconds.observe(timings["total_duration"], labels)
+        @http_request_duration_seconds.observe(timings["total_duration"], labels)
         if redis = timings["redis"]
-          @http_redis_duration_seconds.observe(redis["duration"], labels)
+          @http_request_redis_duration_seconds.observe(redis["duration"], labels)
         end
         if sql = timings["sql"]
-          @http_sql_duration_seconds.observe(sql["duration"], labels)
+          @http_request_sql_duration_seconds.observe(sql["duration"], labels)
         end
       end
       if queue_time = obj["queue_time"]
-        @http_queue_duration_seconds.observe(queue_time, labels)
+        @http_request_queue_duration_seconds.observe(queue_time, labels)
       end
     end
   end

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -111,6 +111,6 @@ class PrometheusWebCollectorTest < Minitest::Test
     metrics = collector.metrics
 
     assert_equal 5, metrics.size
-    assert_includes(metrics.map(&:metric_text).flat_map(&:lines), "http_duration_seconds_bucket{controller=\"home\",action=\"index\",status=\"200\",service=\"service1\",le=\"+Inf\"} 1\n")
+    assert_includes(metrics.map(&:metric_text).flat_map(&:lines), "http_request_duration_seconds_bucket{controller=\"home\",action=\"index\",status=\"200\",service=\"service1\",le=\"+Inf\"} 1\n")
   end
 end


### PR DESCRIPTION
Official prometheus documentation refers to this metric as
`http_request_duration_seconds`.

See: https://prometheus.io/docs/practices/naming/#metric-names

Closes #210 