### PR TITLE
Do not include status label everywhere

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+- FIX: all metrics are exposing status label, and not only `http_requests_total`
 - BREAKING: rename all `http_duration` metrics to `http_request_duration` to match prometheus official naming conventions (See https://prometheus.io/docs/practices/naming/#metric-names).
 
 1.0.1 - 2021-12-22

--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -36,11 +36,12 @@ class PrometheusExporter::Middleware
 
     result
   ensure
-
+    status = (result && result[0]) || -1
     obj = {
       type: "web",
       timings: info,
       queue_time: queue_time,
+      status: status,
       default_labels: default_labels(env, result)
     }
     labels = custom_labels(env)
@@ -52,7 +53,6 @@ class PrometheusExporter::Middleware
   end
 
   def default_labels(env, result)
-    status = (result && result[0]) || -1
     params = env["action_dispatch.request.parameters"]
     action = controller = nil
     if params
@@ -67,8 +67,7 @@ class PrometheusExporter::Middleware
 
     {
       action: action || "other",
-      controller: controller || "other",
-      status: status
+      controller: controller || "other"
     }
   end
 

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -60,20 +60,19 @@ module PrometheusExporter::Server
       custom_labels = obj['custom_labels']
       labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
 
-      @http_requests_total.observe(1, labels)
+      @http_requests_total.observe(1, labels.merge(status: obj["status"]))
 
-      labels_except_status = labels.except("status")
       if timings = obj["timings"]
-        @http_request_duration_seconds.observe(timings["total_duration"], labels_except_status)
+        @http_request_duration_seconds.observe(timings["total_duration"], labels)
         if redis = timings["redis"]
-          @http_request_redis_duration_seconds.observe(redis["duration"], labels_except_status)
+          @http_request_redis_duration_seconds.observe(redis["duration"], labels)
         end
         if sql = timings["sql"]
-          @http_request_sql_duration_seconds.observe(sql["duration"], labels_except_status)
+          @http_request_sql_duration_seconds.observe(sql["duration"], labels)
         end
       end
       if queue_time = obj["queue_time"]
-        @http_request_queue_duration_seconds.observe(queue_time, labels_except_status)
+        @http_request_queue_duration_seconds.observe(queue_time, labels)
       end
     end
   end

--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -62,17 +62,18 @@ module PrometheusExporter::Server
 
       @http_requests_total.observe(1, labels)
 
+      labels_except_status = labels.except("status")
       if timings = obj["timings"]
-        @http_request_duration_seconds.observe(timings["total_duration"], labels)
+        @http_request_duration_seconds.observe(timings["total_duration"], labels_except_status)
         if redis = timings["redis"]
-          @http_request_redis_duration_seconds.observe(redis["duration"], labels)
+          @http_request_redis_duration_seconds.observe(redis["duration"], labels_except_status)
         end
         if sql = timings["sql"]
-          @http_request_sql_duration_seconds.observe(sql["duration"], labels)
+          @http_request_sql_duration_seconds.observe(sql["duration"], labels_except_status)
         end
       end
       if queue_time = obj["queue_time"]
-        @http_request_queue_duration_seconds.observe(queue_time, labels)
+        @http_request_queue_duration_seconds.observe(queue_time, labels_except_status)
       end
     end
   end

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -65,10 +65,10 @@ class PrometheusWebCollectorTest < Minitest::Test
     collector.collect(
       'type' => 'web',
       'timings' => nil,
+      'status' => 200,
       'default_labels' => {
         'controller' => 'home',
-        'action' => 'index',
-        'status' => 200,
+        'action' => 'index'
       },
       'custom_labels' => {
         'service' => 'service1'
@@ -78,7 +78,7 @@ class PrometheusWebCollectorTest < Minitest::Test
     metrics = collector.metrics
 
     assert_equal 5, metrics.size
-    assert(metrics.first.metric_text.include?('http_requests_total{controller="home",action="index",status="200",service="service1"}'))
+    assert(metrics.first.metric_text.include?('http_requests_total{controller="home",action="index",service="service1",status="200"} 1'))
   end
 
   def test_collecting_metrics_in_histogram_mode
@@ -86,6 +86,7 @@ class PrometheusWebCollectorTest < Minitest::Test
 
     collector.collect(
       'type' => 'web',
+      'status' => 200,
       "timings" => {
         "sql" => {
           duration: 0.5,
@@ -96,12 +97,11 @@ class PrometheusWebCollectorTest < Minitest::Test
           count: 4
         },
         "queue" => 0.03,
-        "total_duration" => 1.0
+        "total_duration" => 1.0,
       },
       'default_labels' => {
         'controller' => 'home',
-        'action' => 'index',
-        'status' => 200,
+        'action' => 'index'
       },
       'custom_labels' => {
         'service' => 'service1'
@@ -112,7 +112,7 @@ class PrometheusWebCollectorTest < Minitest::Test
     metrics_lines = metrics.map(&:metric_text).flat_map(&:lines)
 
     assert_equal 5, metrics.size
-    assert_includes(metrics_lines, "http_requests_total{controller=\"home\",action=\"index\",status=\"200\",service=\"service1\"} 1")
+    assert_includes(metrics_lines, "http_requests_total{controller=\"home\",action=\"index\",service=\"service1\",status=\"200\"} 1")
     assert_includes(metrics_lines, "http_request_duration_seconds_bucket{controller=\"home\",action=\"index\",service=\"service1\",le=\"+Inf\"} 1\n")
   end
 end

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -109,8 +109,10 @@ class PrometheusWebCollectorTest < Minitest::Test
     )
 
     metrics = collector.metrics
+    metrics_lines = metrics.map(&:metric_text).flat_map(&:lines)
 
     assert_equal 5, metrics.size
-    assert_includes(metrics.map(&:metric_text).flat_map(&:lines), "http_request_duration_seconds_bucket{controller=\"home\",action=\"index\",status=\"200\",service=\"service1\",le=\"+Inf\"} 1\n")
+    assert_includes(metrics_lines, "http_requests_total{controller=\"home\",action=\"index\",status=\"200\",service=\"service1\"} 1")
+    assert_includes(metrics_lines, "http_request_duration_seconds_bucket{controller=\"home\",action=\"index\",service=\"service1\",le=\"+Inf\"} 1\n")
   end
 end


### PR DESCRIPTION
The `status` label is included in every metrics, and not only in
`http_requests_total`, even though the README states that
```
All metrics have a `controller` and an `action` label.
`http_requests_total` additionally has a (HTTP response) `status` label.
```

This can be a problem as this `status` label can quickly increase the
cardinality of the metrics.

---

This change of behavior was introduced in #148. But I believe this is not the best pattern as it is not useful to have it everywhere, and it can quickly blow up the cardinality. See those [slides about Containing your Cardinality](https://promcon.io/2019-munich/slides/containing-your-cardinality.pdf), especially page 14.