### PR TITLE
Fix: puma thread/memory leak, add thread stop logic to puma instrumentation

### DIFF
--- a/lib/prometheus_exporter/instrumentation/puma.rb
+++ b/lib/prometheus_exporter/instrumentation/puma.rb
@@ -8,7 +8,10 @@ module PrometheusExporter::Instrumentation
     def self.start(client: nil, frequency: 30, labels: {})
       puma_collector = new(labels)
       client ||= PrometheusExporter::Client.default
-      Thread.new do
+
+      stop if @thread
+
+      @thread = Thread.new do
         while true
           begin
             metric = puma_collector.collect
@@ -19,6 +22,13 @@ module PrometheusExporter::Instrumentation
             sleep frequency
           end
         end
+      end
+    end
+
+    def self.stop
+      if t = @thread
+        t.kill
+        @thread = nil
       end
     end
 


### PR DESCRIPTION
The [README](https://github.com/discourse/prometheus_exporter#puma-metrics) for puma recommends using this code to initialize puma instrumentation:

```
after_worker_boot do
  require 'prometheus_exporter/instrumentation'

  PrometheusExporter::Instrumentation::Puma.start
end
```

This results in a puma monitor thread being spawned per worker from the main process. When combined with [puma-worker-killer](https://github.com/schneems/puma_worker_killer) this results in an accumulation of leaked threads and memory. The problematic one is `PrometheusExporter::Instrumentation::Puma.start`, which unconditionally spawns a new thread.

This PR adds the same `stop` / `kill` logic from the `ActiveRecord` and `Process` instrumentation to the `Puma` instrumentation.

When we add this fix:

![memory](https://p46.f4.n0.cdn.getcloudapp.com/items/nOu9Z45q/16e887bf-3bbf-4323-a13b-d39c7f1c958e.png?source=viewer&v=18f9b775c89fe91b3e0108897f958d26)
