### PR TITLE
FIX: ensure threads do not leak when #start is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,10 @@ The easiest way to gather this metrics is to put the following in your `puma.rb`
 # puma.rb config
 after_worker_boot do
   require 'prometheus_exporter/instrumentation'
-  PrometheusExporter::Instrumentation::Puma.start
+  # optional check, avoids spinning up and down threads per worker
+  if !PrometheusExporter::Instrumentation::Puma.started?
+    PrometheusExporter::Instrumentation::Puma.start
+  end
 end
 ```
 

--- a/lib/prometheus_exporter/instrumentation.rb
+++ b/lib/prometheus_exporter/instrumentation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "client"
+require_relative "instrumentation/periodic_stats"
 require_relative "instrumentation/process"
 require_relative "instrumentation/method_profiler"
 require_relative "instrumentation/sidekiq"

--- a/lib/prometheus_exporter/instrumentation/periodic_stats.rb
+++ b/lib/prometheus_exporter/instrumentation/periodic_stats.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module PrometheusExporter::Instrumentation
+  class PeriodicStats
+
+    def self.start(*args, **kwargs)
+      frequency = kwargs[:frequency]
+      client = kwargs[:client] || PrometheusExporter::Client.default
+
+      if !frequency
+        raise ArgumentError.new("Expected a value for frequency argument")
+      end
+
+      if !(Numeric === frequency)
+        raise ArgumentError.new("Expected frequency to be a number")
+      end
+
+      if frequency < 0
+        raise ArgumentError.new("Expected frequency to be a positive number")
+      end
+
+      if !@worker_loop
+        raise ArgumentError.new("Worker loop was not set")
+      end
+
+      klass = self
+
+      stop
+
+      @stop_thread = false
+
+      @thread = Thread.new do
+        while !@stop_thread
+          begin
+            @worker_loop.call
+          rescue => e
+            client.logger.error("#{klass} Prometheus Exporter Failed To Collect Stats #{e}")
+          ensure
+            sleep frequency
+          end
+        end
+      end
+
+    end
+
+    def self.started?
+      !!@thread&.alive?
+    end
+
+    def self.worker_loop(&blk)
+      @worker_loop = blk
+    end
+
+    def self.stop
+      # to avoid a warning
+      @thread = nil if !defined?(@thread)
+
+      if @thread&.alive?
+        @stop_thread = true
+        @thread.wakeup
+        @thread.join
+      end
+      @thread = nil
+    end
+
+  end
+end

--- a/lib/prometheus_exporter/instrumentation/periodic_stats.rb
+++ b/lib/prometheus_exporter/instrumentation/periodic_stats.rb
@@ -6,10 +6,6 @@ module PrometheusExporter::Instrumentation
     def self.start(*args, frequency:, client: nil, **kwargs)
       client ||= PrometheusExporter::Client.default
 
-      if !frequency
-        raise ArgumentError.new("Expected a value for frequency argument")
-      end
-
       if !(Numeric === frequency)
         raise ArgumentError.new("Expected frequency to be a number")
       end

--- a/lib/prometheus_exporter/instrumentation/periodic_stats.rb
+++ b/lib/prometheus_exporter/instrumentation/periodic_stats.rb
@@ -3,9 +3,8 @@
 module PrometheusExporter::Instrumentation
   class PeriodicStats
 
-    def self.start(*args, **kwargs)
-      frequency = kwargs[:frequency]
-      client = kwargs[:client] || PrometheusExporter::Client.default
+    def self.start(*args, frequency:, client: nil, **kwargs)
+      client ||= PrometheusExporter::Client.default
 
       if !frequency
         raise ArgumentError.new("Expected a value for frequency argument")

--- a/lib/prometheus_exporter/instrumentation/sidekiq_stats.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq_stats.rb
@@ -1,22 +1,16 @@
 # frozen_string_literal: true
 
 module PrometheusExporter::Instrumentation
-  class SidekiqStats
+  class SidekiqStats < PeriodicStats
     def self.start(client: nil, frequency: 30)
       client ||= PrometheusExporter::Client.default
       sidekiq_stats_collector = new
 
-      Thread.new do
-        loop do
-          begin
-            client.send_json(sidekiq_stats_collector.collect)
-          rescue StandardError => e
-            STDERR.puts("Prometheus Exporter Failed To Collect Sidekiq Stats metrics #{e}")
-          ensure
-            sleep frequency
-          end
-        end
+      worker_loop do
+        client.send_json(sidekiq_stats_collector.collect)
       end
+
+      super
     end
 
     def collect

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -58,7 +58,11 @@ class PrometheusCollectorTest < Minitest::Test
       metrics_text != ""
     end
 
+    assert_equal(true, PrometheusExporter::Instrumentation::Process.started?)
+
     PrometheusExporter::Instrumentation::Process.stop
+
+    assert_equal(false, PrometheusExporter::Instrumentation::Process.started?)
 
     assert_match(/heap_live_slots/, metrics_text)
     assert_match(/hello.*custom label/, metrics_text)
@@ -425,7 +429,6 @@ class PrometheusCollectorTest < Minitest::Test
       "retry" => false,
       "class" => "WorkerWithCustomLabels"
     }
-    custom_labels = { from_worker: 'test1' }
 
     client = Minitest::Mock.new
 


### PR DESCRIPTION
Periodic instrumentation now follows a general pattern where they
inherit from PeriodicStats.

This implementation ensures proper management of backing thread

1. All classes inheriting now have a .started? method to determine
if instrument is started

2. All classes implement a clean .stop method for stopping active
periodic instrumentation

3. Consumers of the class get to write less code repeat code due
to worker_loop
