### PR TITLE
Allow gem to be used with ruby 2.5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
         activerecord: [60, 61]
 
     steps:

--- a/gemfiles/ar_60.gemfile
+++ b/gemfiles/ar_60.gemfile
@@ -2,4 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "activerecord", "~> 6.0.0"
+gem "mini_racer", "~> 0.5.0"
+
 gemspec path: "../"

--- a/gemfiles/ar_61.gemfile
+++ b/gemfiles/ar_61.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 6.1.0"
+gem "mini_racer", "~> 0.5.0"
 
 gemspec path: "../"
+

--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-stub-const", "~> 0.6"
   spec.add_development_dependency "rubocop-discourse", ">2"
   spec.add_development_dependency "appraisal", "~> 2.3"
-  spec.add_development_dependency "activerecord", "= 5.2.0"
-  spec.add_development_dependency "activesupport", "= 5.2.0"
-  spec.add_development_dependency "railties", "= 5.2.0"
+  spec.add_development_dependency "activerecord", ">= 5.2.0"
+  spec.add_development_dependency "activesupport", ">= 5.2.0"
+  spec.add_development_dependency "railties", ">= 5.2.0"
 
   if !RUBY_ENGINE == 'jruby'
     spec.add_development_dependency "raindrops", "~> 0.19"

--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -31,16 +31,19 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "guard", "~> 2.0"
-  spec.add_development_dependency "mini_racer", "~> 0.5.0"
+  spec.add_development_dependency "mini_racer", "~> 0.4.0"
   spec.add_development_dependency "guard-minitest", "~> 2.0"
   spec.add_development_dependency "oj", "~> 3.0"
-  spec.add_development_dependency "rack-test", "~> 0.8.3"
+  spec.add_development_dependency "rack-test", "~> 0.6.3"
   spec.add_development_dependency "minitest-stub-const", "~> 0.6"
   spec.add_development_dependency "rubocop-discourse", ">2"
   spec.add_development_dependency "appraisal", "~> 2.3"
-  spec.add_development_dependency "activerecord", "~> 6.0.0"
+  spec.add_development_dependency "activerecord", "= 5.2.0"
+  spec.add_development_dependency "activesupport", "= 5.2.0"
+  spec.add_development_dependency "railties", "= 5.2.0"
+
   if !RUBY_ENGINE == 'jruby'
     spec.add_development_dependency "raindrops", "~> 0.19"
   end
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.5.5'
 end

--- a/test/instrumentation/active_record_test.rb
+++ b/test/instrumentation/active_record_test.rb
@@ -12,8 +12,6 @@ class PrometheusInstrumentationActiveRecordTest < Minitest::Test
     # With this trick this variable with be accessible with ::ObjectSpace
     @pool = if active_record_version >= Gem::Version.create('6.1.0.rc1')
       active_record61_pool
-    elsif active_record_version >= Gem::Version.create('6.0.0')
-      active_record60_pool
     elsif active_record_version >= Gem::Version.create('5.2.0')
       active_record52_pool
     else
@@ -54,10 +52,6 @@ class PrometheusInstrumentationActiveRecordTest < Minitest::Test
   end
 
   def active_record52_pool
-    ::ActiveRecord::ConnectionAdapters::ConnectionPool.new(OpenStruct.new(config: {}))
-  end
-
-  def active_record60_pool
     ::ActiveRecord::ConnectionAdapters::ConnectionPool.new(OpenStruct.new(config: {}))
   end
 

--- a/test/instrumentation/active_record_test.rb
+++ b/test/instrumentation/active_record_test.rb
@@ -14,6 +14,8 @@ class PrometheusInstrumentationActiveRecordTest < Minitest::Test
       active_record61_pool
     elsif active_record_version >= Gem::Version.create('6.0.0')
       active_record60_pool
+    elsif active_record_version >= Gem::Version.create('5.2.0')
+      active_record52_pool
     else
       raise 'unsupported active_record version'
     end
@@ -49,6 +51,10 @@ class PrometheusInstrumentationActiveRecordTest < Minitest::Test
 
   def active_record_version
     Gem.loaded_specs["activerecord"].version
+  end
+
+  def active_record52_pool
+    ::ActiveRecord::ConnectionAdapters::ConnectionPool.new(OpenStruct.new(config: {}))
   end
 
   def active_record60_pool


### PR DESCRIPTION
Since it is not possible to update ruby on the api servers at the
current time, prometheus_exporter needs to continue working with
the installed version (2.5.5) This change means that we can use
the recently added features without upgrading ruby