### PR TITLE
FIX: unicorn instrumentation not required correctly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.0.2 - 2022-02-25
+
+- FIX: runner was not requiring unicorn integration correctly leading to a crash
+
 2.0.1 - 2022-02-24
 
 - FIX: ensure threads do not leak when calling #start repeatedly on instrumentation classes, this is an urgent patch for Puma integration

--- a/lib/prometheus_exporter/server/runner.rb
+++ b/lib/prometheus_exporter/server/runner.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../client'
-require_relative '../instrumentation/unicorn'
 
 module PrometheusExporter::Server
   class RunnerException < StandardError; end
@@ -39,6 +38,9 @@ module PrometheusExporter::Server
       end
 
       if unicorn_listen_address && unicorn_pid_file
+
+        require_relative '../instrumentation'
+
         local_client = PrometheusExporter::LocalClient.new(collector: collector)
         PrometheusExporter::Instrumentation::Unicorn.start(
           pid_file: unicorn_pid_file,

--- a/lib/prometheus_exporter/version.rb
+++ b/lib/prometheus_exporter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PrometheusExporter
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
Runner.rb would crash due to only partially requiring unicorn
integration

Changes it so it is defer required
