### PR TITLE
Add /ping endpoint which only returns PONG

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,26 @@ You can also pass a log level (default is [`Logger::WARN`](https://ruby-doc.org/
 PrometheusExporter::Client.new(log_level: Logger::DEBUG)
 ```
 
+## Docker/Kubernetes Healthcheck
+
+A `/ping` endpoint which only returns `PONG` is available so you can run container healthchecks :
+
+Example:
+
+```yml
+services:
+  rails-exporter:
+    command:
+      - bin/prometheus_exporter
+      - -b
+      - 0.0.0.0
+    healthcheck:
+      test: ["CMD", "curl", "--silent", "--show-error", "--fail", "--max-time", "3", "http://0.0.0.0:9394/ping"]
+      timeout: 3s
+      interval: 10s
+      retries: 5
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/discourse/prometheus_exporter. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -73,9 +73,11 @@ module PrometheusExporter::Server
           end
         elsif req.path == '/send-metrics'
           handle_metrics(req, res)
+        elsif req.path == '/ping'
+          res.body = 'PONG'
         else
           res.status = 404
-          res.body = "Not Found! The Prometheus Ruby Exporter only listens on /metrics and /send-metrics"
+          res.body = "Not Found! The Prometheus Ruby Exporter only listens on /ping, /metrics and /send-metrics"
         end
       end
     end

--- a/test/server/web_server_test.rb
+++ b/test/server/web_server_test.rb
@@ -255,4 +255,27 @@ class PrometheusExporterTest < Minitest::Test
     client.stop rescue nil
     server.stop rescue nil
   end
+
+  def test_it_responds_to_ping
+    collector = DemoCollector.new
+    port = find_free_port
+
+    server = PrometheusExporter::Server::WebServer.new port: port, collector: collector
+    server.start
+
+    client = PrometheusExporter::Client.new host: "localhost", port: port, thread_sleep: 0.001
+
+    Net::HTTP.new("localhost", port).start do |http|
+      request = Net::HTTP::Get.new "/ping"
+
+      http.request(request) do |response|
+        assert_equal("200", response.code)
+        assert_match(/PONG/, response.body)
+      end
+    end
+
+  ensure
+    client.stop rescue nil
+    server.stop rescue nil
+  end
 end


### PR DESCRIPTION
So users can set an healthcheck in their `docker-compose.yml` file :

```yml
    healthcheck:
      test: ["CMD", "curl", "--silent", "--show-error", "--fail", "--max-time", "3", "http://0.0.0.0:9394/ping"]
      timeout: 3s
      interval: 10s
      retries: 5
```