### PR TITLE
Pass msg hash to Sidekiq jobs custom_labels function

### DIFF
--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -16,7 +16,7 @@ module PrometheusExporter::Instrumentation
         job_is_fire_and_forget = job["retry"] == false
 
         worker_class = Object.const_get(job["class"])
-        worker_custom_labels = self.get_worker_custom_labels(worker_class)
+        worker_custom_labels = self.get_worker_custom_labels(worker_class, job)
 
         unless job_is_fire_and_forget
           PrometheusExporter::Client.default.send_json(
@@ -29,8 +29,15 @@ module PrometheusExporter::Instrumentation
       end
     end
 
-    def self.get_worker_custom_labels(worker_class)
-      worker_class.respond_to?(:custom_labels) ? worker_class.custom_labels : {}
+    def self.get_worker_custom_labels(worker_class, msg)
+      return {} unless worker_class.respond_to?(:custom_labels)
+      method_arity = worker_class.method(:custom_labels).arity
+
+      if method_arity > 0
+        worker_class.custom_labels(msg)
+      else
+        worker_class.custom_labels
+      end
     end
 
     def initialize(client: nil)
@@ -56,7 +63,7 @@ module PrometheusExporter::Instrumentation
         success: success,
         shutdown: shutdown,
         duration: duration,
-        custom_labels: self.class.get_worker_custom_labels(worker.class)
+        custom_labels: self.class.get_worker_custom_labels(worker.class, msg)
       )
     end
 

--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -31,6 +31,8 @@ module PrometheusExporter::Instrumentation
 
     def self.get_worker_custom_labels(worker_class, msg)
       return {} unless worker_class.respond_to?(:custom_labels)
+
+      # TODO remove when version 3.0.0 is released
       method_arity = worker_class.method(:custom_labels).arity
 
       if method_arity > 0

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -378,7 +378,7 @@ class PrometheusCollectorTest < Minitest::Test
 
   def test_it_can_collect_sidekiq_metrics_with_custom_labels_from_job
     worker_class = 'WorkerWithCustomLabelsFromJob'
-    msg = { 'wrapped' => worker_class, 'args' => ['arg_one', ] }
+    msg = { 'wrapped' => worker_class, 'args' => ['arg_one'] }
     queue = "default"
 
     client = Minitest::Mock.new


### PR DESCRIPTION
[A previous PR](https://github.com/discourse/prometheus_exporter/pull/208) added the option to define a class method on Sidekiq worker classes. One thing that was accidentally left out is the ability for this function to use the arguments to an individual job run to generate the custom labels. I changed the code to pass the jobs hash to the custom_labels class function if it is defined.

The hash only gets passed if the custom_labels function expects > 0 arguments. This avoids a breaking change with the previous version where a custom_labels function on a worker class didn't take any arguments.