### PR TITLE
Ability to choose style of instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ Ensure you run the exporter in a monitored background process:
 $ bundle exec prometheus_exporter
 ```
 
+#### Choosing the style of method patching
+
+By default, `prometheus_exporter` uses `alias_method` to instrument methods used by SQL and Redis as it is the fastest approach (see [this article](https://samsaffron.com/archive/2017/10/18/fastest-way-to-profile-a-method-in-ruby)). You may desire to add additional instrumentation libraries beyond `prometheus_exporter` to your app. This can become problematic if these other libraries instead use `prepend` to instrument methods. To resolve this, you can tell the middleware to instrument using `prepend` by passing an `instrument` option like so:
+
+```ruby
+Rails.application.middleware.unshift PrometheusExporter::Middleware, instrument: :prepend
+```
+
 #### Metrics collected by Rails integration middleware
 
 | Type    | Name                                   | Description                                                 |

--- a/lib/prometheus_exporter/instrumentation/method_profiler.rb
+++ b/lib/prometheus_exporter/instrumentation/method_profiler.rb
@@ -4,30 +4,14 @@
 module PrometheusExporter::Instrumentation; end
 
 class PrometheusExporter::Instrumentation::MethodProfiler
-  def self.patch(klass, methods, name)
-    patch_source_line = __LINE__ + 3
-    patches = methods.map do |method_name|
-      <<~RUBY
-      unless defined?(#{method_name}__mp_unpatched)
-        alias_method :#{method_name}__mp_unpatched, :#{method_name}
-        def #{method_name}(*args, &blk)
-          unless prof = Thread.current[:_method_profiler]
-            return #{method_name}__mp_unpatched(*args, &blk)
-          end
-          begin
-            start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-            #{method_name}__mp_unpatched(*args, &blk)
-          ensure
-            data = (prof[:#{name}] ||= {duration: 0.0, calls: 0})
-            data[:duration] += Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-            data[:calls] += 1
-          end
-        end
-      end
-      RUBY
-    end.join("\n")
-
-    klass.class_eval patches, __FILE__, patch_source_line
+  def self.patch(klass, methods, name, instrument:)
+    if instrument == :alias_method
+      patch_using_alias_method(klass, methods, name)
+    elsif instrument == :prepend
+      patch_using_prepend(klass, methods, name)
+    else
+      raise ArgumentError, "instrument must be :alias_method or :prepend"
+    end
   end
 
   def self.transfer
@@ -54,5 +38,58 @@ class PrometheusExporter::Instrumentation::MethodProfiler
       data[:total_duration] = finish - start
     end
     data
+  end
+
+private
+
+  def self.patch_using_prepend(klass, methods, name)
+    prepend_instument = Module.new
+    patch_source_line = __LINE__ + 3
+    patches = methods.map do |method_name|
+      <<~RUBY
+        def #{method_name}(*args, &blk)
+          unless prof = Thread.current[:_method_profiler]
+            return super
+          end
+          begin
+            start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            super
+          ensure
+            data = (prof[:#{name}] ||= {duration: 0.0, calls: 0})
+            data[:duration] += Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+            data[:calls] += 1
+          end
+        end
+      RUBY
+    end.join("\n")
+
+    prepend_instument.module_eval patches, __FILE__, patch_source_line
+    klass.prepend(prepend_instument)
+  end
+
+  def self.patch_using_alias_method(klass, methods, name)
+    patch_source_line = __LINE__ + 3
+    patches = methods.map do |method_name|
+      <<~RUBY
+      unless defined?(#{method_name}__mp_unpatched)
+        alias_method :#{method_name}__mp_unpatched, :#{method_name}
+        def #{method_name}(*args, &blk)
+          unless prof = Thread.current[:_method_profiler]
+            return #{method_name}__mp_unpatched(*args, &blk)
+          end
+          begin
+            start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            #{method_name}__mp_unpatched(*args, &blk)
+          ensure
+            data = (prof[:#{name}] ||= {duration: 0.0, calls: 0})
+            data[:duration] += Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+            data[:calls] += 1
+          end
+        end
+      end
+      RUBY
+    end.join("\n")
+
+    klass.class_eval patches, __FILE__, patch_source_line
   end
 end


### PR DESCRIPTION
`prometheus_exporter` cannot reliably be used with other instrumentation libraries that use `prepend` to instrument methods as described in https://github.com/discourse/prometheus_exporter/issues/159. The goal of this PR is to provide the ability to have `prometheus_exporter` instrument using `prepend`, while still maintaining the default of `alias_method`.