### PR TITLE
FIX for ruby 3 incompatibility in sidekiq middleware, fixes #229

### DIFF
--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -33,8 +33,8 @@ module PrometheusExporter::Instrumentation
       worker_class.respond_to?(:custom_labels) ? worker_class.custom_labels : {}
     end
 
-    def initialize(client: nil)
-      @client = client || PrometheusExporter::Client.default
+    def initialize(options = { client: nil })
+      @client = options.fetch(:client, nil) || PrometheusExporter::Client.default
     end
 
     def call(worker, msg, queue)

--- a/test/sidekiq_middleware_test.rb
+++ b/test/sidekiq_middleware_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'minitest/stub_const'
+require_relative 'test_helper'
+require 'prometheus_exporter/instrumentation/sidekiq'
+
+class PrometheusExporterSidekiqMiddlewareTest < Minitest::Test
+
+  class FakeClient
+  end
+
+  def client
+    @client ||= FakeClient.new
+  end
+
+  class FakeSidekiqMiddlewareChainEntry
+    attr_reader :klass
+
+    def initialize(klass, *args)
+      @klass = klass
+      @args = args
+    end
+
+    def make_new
+      @klass.new(*@args)
+    end
+  end
+
+  def test_initiating_middlware
+    middleware_entry = FakeSidekiqMiddlewareChainEntry.new(
+      PrometheusExporter::Instrumentation::Sidekiq, { client: client })
+    assert_instance_of PrometheusExporter::Instrumentation::Sidekiq, middleware_entry.make_new
+  end
+
+end


### PR DESCRIPTION
See #229 for more details.

The test case might seem a bit weird, but I didn't find a more elegant way to reproduce Sidekiq's middleware initialization. So definitely open for suggestions.

- Sidekiq middleware chain for reference: https://github.com/mperham/sidekiq/blob/main/lib/sidekiq/middleware/chain.rb