### PR TITLE
Fix merge in web collector

### DIFF
--- a/lib/prometheus_exporter/server/web_collector.rb
+++ b/lib/prometheus_exporter/server/web_collector.rb
@@ -60,7 +60,7 @@ module PrometheusExporter::Server
       custom_labels = obj['custom_labels']
       labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
 
-      @http_requests_total.observe(1, labels.merge(status: obj["status"]))
+      @http_requests_total.observe(1, labels.merge("status" => obj["status"]))
 
       if timings = obj["timings"]
         @http_request_duration_seconds.observe(timings["total_duration"], labels)

--- a/test/server/web_collector_test.rb
+++ b/test/server/web_collector_test.rb
@@ -81,6 +81,27 @@ class PrometheusWebCollectorTest < Minitest::Test
     assert(metrics.first.metric_text.include?('http_requests_total{controller="home",action="index",service="service1",status="200"} 1'))
   end
 
+  def test_collecting_metrics_merging_custom_labels_and_status
+    collector.collect(
+      'type' => 'web',
+      'timings' => nil,
+      'status' => 200,
+      'default_labels' => {
+        'controller' => 'home',
+        'action' => 'index'
+      },
+      'custom_labels' => {
+        'service' => 'service1',
+        'status' => 200
+      }
+    )
+
+    metrics = collector.metrics
+
+    assert_equal 5, metrics.size
+    assert(metrics.first.metric_text.include?('http_requests_total{controller="home",action="index",service="service1",status="200"} 1'))
+  end
+
   def test_collecting_metrics_in_histogram_mode
     PrometheusExporter::Metric::Base.default_aggregation = PrometheusExporter::Metric::Histogram
 


### PR DESCRIPTION
Hi! Thanks for your work on prometheus_exporter :)
When upgrading prometheus_exporter, I noticed that status is no longer included in all requests, as per #216 . However, we would still like to include it in our custom labels, since we have some dashboards which use it.

When we tested including it ourselves, I got some errors from prometheus because there was an invalid metric. The metric had "status" twice. It seems that the issue is that the metric coming from the json serializer has `status` as a string, while the merge had a symbol.

This PR adds a test to check that the merge is correct and corrects the merge to use a string as well. 