### PR TITLE
Order histogram buckets in increasing numerical order

### DIFF
--- a/lib/prometheus_exporter/metric/histogram.rb
+++ b/lib/prometheus_exporter/metric/histogram.rb
@@ -19,7 +19,7 @@ module PrometheusExporter::Metric
 
     def initialize(name, help, opts = {})
       super(name, help)
-      @buckets = (opts[:buckets] || self.class.default_buckets).sort.reverse
+      @buckets = (opts[:buckets] || self.class.default_buckets).sort
       reset!
     end
 
@@ -57,11 +57,11 @@ module PrometheusExporter::Metric
         first = false
         count = @counts[labels]
         sum = @sums[labels]
-        text << "#{prefix(@name)}_bucket#{labels_text(with_bucket(labels, "+Inf"))} #{count}\n"
         @buckets.each do |bucket|
           value = @observations[labels][bucket]
           text << "#{prefix(@name)}_bucket#{labels_text(with_bucket(labels, bucket.to_s))} #{value}\n"
         end
+        text << "#{prefix(@name)}_bucket#{labels_text(with_bucket(labels, "+Inf"))} #{count}\n"
         text << "#{prefix(@name)}_count#{labels_text(labels)} #{count}\n"
         text << "#{prefix(@name)}_sum#{labels_text(labels)} #{sum}"
       end
@@ -91,7 +91,7 @@ module PrometheusExporter::Metric
     end
 
     def fill_buckets(value, buckets)
-      @buckets.each do |b|
+      @buckets.reverse.each do |b|
         break if value > b
         buckets[b] += 1
       end

--- a/test/metric/histogram_test.rb
+++ b/test/metric/histogram_test.rb
@@ -25,18 +25,18 @@ module PrometheusExporter::Metric
       expected = <<~TEXT
         # HELP a_histogram my amazing histogram
         # TYPE a_histogram histogram
-        a_histogram_bucket{le="+Inf"} 7
-        a_histogram_bucket{le="10.0"} 7
-        a_histogram_bucket{le="5.0"} 7
-        a_histogram_bucket{le="2.5"} 7
-        a_histogram_bucket{le="1"} 7
-        a_histogram_bucket{le="0.5"} 3
-        a_histogram_bucket{le="0.25"} 3
-        a_histogram_bucket{le="0.1"} 2
-        a_histogram_bucket{le="0.05"} 0
-        a_histogram_bucket{le="0.025"} 0
-        a_histogram_bucket{le="0.01"} 0
         a_histogram_bucket{le="0.005"} 0
+        a_histogram_bucket{le="0.01"} 0
+        a_histogram_bucket{le="0.025"} 0
+        a_histogram_bucket{le="0.05"} 0
+        a_histogram_bucket{le="0.1"} 2
+        a_histogram_bucket{le="0.25"} 3
+        a_histogram_bucket{le="0.5"} 3
+        a_histogram_bucket{le="1"} 7
+        a_histogram_bucket{le="2.5"} 7
+        a_histogram_bucket{le="5.0"} 7
+        a_histogram_bucket{le="10.0"} 7
+        a_histogram_bucket{le="+Inf"} 7
         a_histogram_count 7
         a_histogram_sum 3.1400040000000002
       TEXT
@@ -58,32 +58,32 @@ module PrometheusExporter::Metric
       expected = <<~TEXT
         # HELP a_histogram my amazing histogram
         # TYPE a_histogram histogram
-        a_histogram_bucket{le="+Inf"} 4
-        a_histogram_bucket{le="10.0"} 4
-        a_histogram_bucket{le="5.0"} 4
-        a_histogram_bucket{le="2.5"} 4
-        a_histogram_bucket{le="1"} 4
-        a_histogram_bucket{le="0.5"} 2
-        a_histogram_bucket{le="0.25"} 2
-        a_histogram_bucket{le="0.1"} 1
-        a_histogram_bucket{le="0.05"} 0
-        a_histogram_bucket{le="0.025"} 0
-        a_histogram_bucket{le="0.01"} 0
         a_histogram_bucket{le="0.005"} 0
+        a_histogram_bucket{le="0.01"} 0
+        a_histogram_bucket{le="0.025"} 0
+        a_histogram_bucket{le="0.05"} 0
+        a_histogram_bucket{le="0.1"} 1
+        a_histogram_bucket{le="0.25"} 2
+        a_histogram_bucket{le="0.5"} 2
+        a_histogram_bucket{le="1"} 4
+        a_histogram_bucket{le="2.5"} 4
+        a_histogram_bucket{le="5.0"} 4
+        a_histogram_bucket{le="10.0"} 4
+        a_histogram_bucket{le="+Inf"} 4
         a_histogram_count 4
         a_histogram_sum 1.520002
-        a_histogram_bucket{name="bob",family="skywalker",le="+Inf"} 3
-        a_histogram_bucket{name="bob",family="skywalker",le="10.0"} 3
-        a_histogram_bucket{name="bob",family="skywalker",le="5.0"} 3
-        a_histogram_bucket{name="bob",family="skywalker",le="2.5"} 3
-        a_histogram_bucket{name="bob",family="skywalker",le="1"} 3
-        a_histogram_bucket{name="bob",family="skywalker",le="0.5"} 1
-        a_histogram_bucket{name="bob",family="skywalker",le="0.25"} 1
-        a_histogram_bucket{name="bob",family="skywalker",le="0.1"} 1
-        a_histogram_bucket{name="bob",family="skywalker",le="0.05"} 0
-        a_histogram_bucket{name="bob",family="skywalker",le="0.025"} 0
-        a_histogram_bucket{name="bob",family="skywalker",le="0.01"} 0
         a_histogram_bucket{name="bob",family="skywalker",le="0.005"} 0
+        a_histogram_bucket{name="bob",family="skywalker",le="0.01"} 0
+        a_histogram_bucket{name="bob",family="skywalker",le="0.025"} 0
+        a_histogram_bucket{name="bob",family="skywalker",le="0.05"} 0
+        a_histogram_bucket{name="bob",family="skywalker",le="0.1"} 1
+        a_histogram_bucket{name="bob",family="skywalker",le="0.25"} 1
+        a_histogram_bucket{name="bob",family="skywalker",le="0.5"} 1
+        a_histogram_bucket{name="bob",family="skywalker",le="1"} 3
+        a_histogram_bucket{name="bob",family="skywalker",le="2.5"} 3
+        a_histogram_bucket{name="bob",family="skywalker",le="5.0"} 3
+        a_histogram_bucket{name="bob",family="skywalker",le="10.0"} 3
+        a_histogram_bucket{name="bob",family="skywalker",le="+Inf"} 3
         a_histogram_count{name="bob",family="skywalker"} 3
         a_histogram_sum{name="bob",family="skywalker"} 1.79
       TEXT
@@ -102,16 +102,16 @@ module PrometheusExporter::Metric
       expected = <<~TEXT
         # HELP a_histogram my amazing histogram
         # TYPE a_histogram histogram
-        a_histogram_bucket{le="+Inf"} 3
-        a_histogram_bucket{le="3"} 2
-        a_histogram_bucket{le="2"} 2
         a_histogram_bucket{le="1"} 1
+        a_histogram_bucket{le="2"} 2
+        a_histogram_bucket{le="3"} 2
+        a_histogram_bucket{le="+Inf"} 3
         a_histogram_count 3
         a_histogram_sum 6.0
-        a_histogram_bucket{name="gargamel",le="+Inf"} 1
-        a_histogram_bucket{name="gargamel",le="3"} 1
-        a_histogram_bucket{name="gargamel",le="2"} 1
         a_histogram_bucket{name="gargamel",le="1"} 0
+        a_histogram_bucket{name="gargamel",le="2"} 1
+        a_histogram_bucket{name="gargamel",le="3"} 1
+        a_histogram_bucket{name="gargamel",le="+Inf"} 1
         a_histogram_count{name="gargamel"} 1
         a_histogram_sum{name="gargamel"} 2.0
       TEXT
@@ -155,14 +155,14 @@ module PrometheusExporter::Metric
     end
 
     it 'uses the default buckets for instance' do
-      assert_equal(histogram.buckets, Histogram::DEFAULT_BUCKETS.sort.reverse)
+      assert_equal(histogram.buckets, Histogram::DEFAULT_BUCKETS)
     end
 
     it 'uses the the custom default buckets for instance' do
       custom_buckets = [0.005, 0.1, 1, 2, 5, 10]
       Histogram.default_buckets = custom_buckets
 
-      assert_equal(histogram.buckets, custom_buckets.sort.reverse)
+      assert_equal(histogram.buckets, custom_buckets)
 
       Histogram.default_buckets = Histogram::DEFAULT_BUCKETS
     end
@@ -171,7 +171,7 @@ module PrometheusExporter::Metric
       buckets = [0.1, 0.2, 0.3]
       histogram = Histogram.new('test_bucktets', 'I have specified buckets', buckets: buckets)
 
-      assert_equal(histogram.buckets, buckets.sort.reverse)
+      assert_equal(histogram.buckets, buckets)
     end
   end
 end

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -223,18 +223,18 @@ class PrometheusCollectorTest < Minitest::Test
     text = <<~TXT
       # HELP test_name test_help
       # TYPE test_name histogram
-      test_name_bucket{key1=\"test1\",le=\"+Inf\"} 2
-      test_name_bucket{key1=\"test1\",le=\"10.0\"} 2
-      test_name_bucket{key1=\"test1\",le=\"5.0\"} 0
-      test_name_bucket{key1=\"test1\",le=\"2.5\"} 0
-      test_name_bucket{key1=\"test1\",le=\"1\"} 0
-      test_name_bucket{key1=\"test1\",le=\"0.5\"} 0
-      test_name_bucket{key1=\"test1\",le=\"0.25\"} 0
-      test_name_bucket{key1=\"test1\",le=\"0.1\"} 0
-      test_name_bucket{key1=\"test1\",le=\"0.05\"} 0
-      test_name_bucket{key1=\"test1\",le=\"0.025\"} 0
-      test_name_bucket{key1=\"test1\",le=\"0.01\"} 0
       test_name_bucket{key1=\"test1\",le=\"0.005\"} 0
+      test_name_bucket{key1=\"test1\",le=\"0.01\"} 0
+      test_name_bucket{key1=\"test1\",le=\"0.025\"} 0
+      test_name_bucket{key1=\"test1\",le=\"0.05\"} 0
+      test_name_bucket{key1=\"test1\",le=\"0.1\"} 0
+      test_name_bucket{key1=\"test1\",le=\"0.25\"} 0
+      test_name_bucket{key1=\"test1\",le=\"0.5\"} 0
+      test_name_bucket{key1=\"test1\",le=\"1\"} 0
+      test_name_bucket{key1=\"test1\",le=\"2.5\"} 0
+      test_name_bucket{key1=\"test1\",le=\"5.0\"} 0
+      test_name_bucket{key1=\"test1\",le=\"10.0\"} 2
+      test_name_bucket{key1=\"test1\",le=\"+Inf\"} 2
       test_name_count{key1=\"test1\"} 2
       test_name_sum{key1=\"test1\"} 12.0
     TXT
@@ -260,10 +260,10 @@ class PrometheusCollectorTest < Minitest::Test
     text = <<~TXT
       # HELP test_name test_help
       # TYPE test_name histogram
-      test_name_bucket{key1=\"test1\",le=\"+Inf\"} 2
-      test_name_bucket{key1=\"test1\",le=\"7\"} 2
-      test_name_bucket{key1=\"test1\",le=\"6\"} 2
       test_name_bucket{key1=\"test1\",le=\"5\"} 0
+      test_name_bucket{key1=\"test1\",le=\"6\"} 2
+      test_name_bucket{key1=\"test1\",le=\"7\"} 2
+      test_name_bucket{key1=\"test1\",le=\"+Inf\"} 2
       test_name_count{key1=\"test1\"} 2
       test_name_sum{key1=\"test1\"} 12.0
     TXT


### PR DESCRIPTION
The [docs on the Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#histograms-and-summaries) say

> The buckets of a histogram and the quantiles of a summary must appear in increasing numerical order of their label values (for the le or the quantile label, respectively).

This hasn't been a problem with the Prometheus versions we've used up to now. However, I have a client that's migrating to GCP right now where they're using the [Managed Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) offering, which doesn't process the wrongly ordered histogram buckets.

Not sure what (custom?) Prometheus version GCP is using here (it's all pretty much hidden), though.