### PR TITLE
Update example custom collector to inherit from BaseCollector

### DIFF
--- a/examples/custom_collector.rb
+++ b/examples/custom_collector.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MyCustomCollector < PrometheusExporter::Server::Collector
+class MyCustomCollector < PrometheusExporter::Server::BaseCollector
   def initialize
     @gauge1 = PrometheusExporter::Metric::Gauge.new("thing1", "I am thing 1")
     @gauge2 = PrometheusExporter::Metric::Gauge.new("thing2", "I am thing 2")


### PR DESCRIPTION
The documentation advises that a custom collector should inherit from
`PrometheusExporter::Server::BaseCollector` and the example in the docs
does so. The code example inherits from `Collector` instead. We found
this seemed to work in development but would behave unreliably in
production. This change updates the example to match the code snippet in
the Readme.