### PR TITLE
Allow DelayedJob to be extended and JOB_CLASS_REGEXP redefined

### DIFF
--- a/lib/prometheus_exporter/instrumentation/delayed_job.rb
+++ b/lib/prometheus_exporter/instrumentation/delayed_job.rb
@@ -40,7 +40,7 @@ module PrometheusExporter::Instrumentation
 
       @client.send_json(
         type: "delayed_job",
-        name: job.handler.to_s.match(JOB_CLASS_REGEXP).to_a[1].to_s,
+        name: job.handler.to_s.match(self.class::JOB_CLASS_REGEXP).to_a[1].to_s,
         queue_name: job.queue,
         success: success,
         duration: duration,


### PR DESCRIPTION
In our testing and use of this tool, we found that the value of
JOB_CLASS_REGEXP for the DelayedJob instrumentation didn't match
what our values looked like.

The original code is looking for something like this:

```
job_class: MyClass
```

However, in our environment, our values look something more like
this (YAML data with no "job_class" to be seen):

```
--- !ruby/struct:MyJob
endpoint_id:
payload:
```

Anyway, we wanted to just change the JOB_CLASS_REGEXP value by subclassing
DelayedJob and registering that plugin, but it didn't work because even
the subclass would use the original class's value of JOB_CLASS_REGEXP.

This update switches the use of JOB_CLASS_REGEXP to allow for a subclass
to override the value using `self.class::JOB_CLASS_REGEXP`.

Our desired workflow is to allow for this:

```
class MyDelayedJob < PrometheusExporter::Instrumentation::DelayedJob
  JOB_CLASS_REGEXP = %r{ruby/(?:object|struct):\s*(\w+)}.freeze
end
MyDelayedJob.register_plugin
```