### PR TITLE
FIX: correct instrumentation for Redis 5

### DIFF
--- a/lib/prometheus_exporter/instrumentation/method_profiler.rb
+++ b/lib/prometheus_exporter/instrumentation/method_profiler.rb
@@ -40,10 +40,7 @@ class PrometheusExporter::Instrumentation::MethodProfiler
     data
   end
 
-private
-
-  def self.patch_using_prepend(klass, methods, name)
-    prepend_instument = Module.new
+  def self.define_methods_on_module(klass, methods, name)
     patch_source_line = __LINE__ + 3
     patches = methods.map do |method_name|
       <<~RUBY
@@ -63,7 +60,12 @@ private
       RUBY
     end.join("\n")
 
-    prepend_instument.module_eval patches, __FILE__, patch_source_line
+    klass.module_eval patches, __FILE__, patch_source_line
+  end
+
+  def self.patch_using_prepend(klass, methods, name)
+    prepend_instument = Module.new
+    define_methods_on_module(klass, methods, name)
     klass.prepend(prepend_instument)
   end
 

--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", ">= 0.69"
   spec.add_development_dependency "bundler", ">= 2.1.4"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest", "~> 5.15.0" # https://github.com/qrush/m/issues/93
   spec.add_development_dependency "guard", "~> 2.0"
   spec.add_development_dependency "mini_racer", "~> 0.5.0"
   spec.add_development_dependency "guard-minitest", "~> 2.0"
@@ -39,6 +39,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-discourse", ">2"
   spec.add_development_dependency "appraisal", "~> 2.3"
   spec.add_development_dependency "activerecord", "~> 6.0.0"
+  spec.add_development_dependency "redis", "> 5"
+  spec.add_development_dependency "m"
   if !RUBY_ENGINE == 'jruby'
     spec.add_development_dependency "raindrops", "~> 0.19"
   end

--- a/test/metric/histogram_test.rb
+++ b/test/metric/histogram_test.rb
@@ -124,7 +124,10 @@ module PrometheusExporter::Metric
       histogram.observe(0.7, name: "bob", family: "skywalker")
       histogram.observe(0.99, name: "bob", family: "skywalker")
 
-      assert_equal(histogram.to_h, { name: "bob", family: "skywalker" } => { "count" => 3, "sum" => 1.79 })
+      key = { name: "bob", family: "skywalker" }
+      val = { "count" => 3, "sum" => 1.79 }
+
+      assert_equal(histogram.to_h, key => val)
     end
 
     it "can correctly remove histograms" do
@@ -137,7 +140,10 @@ module PrometheusExporter::Metric
       histogram.remove(name: "gandalf", family: "skywalker")
       histogram.remove(name: "jane", family: "skywalker")
 
-      assert_equal(histogram.to_h, { name: "bob", family: "skywalker" } => { "count" => 3, "sum" => 1.79 })
+      key = { name: "bob", family: "skywalker" }
+      val = { "count" => 3, "sum" => 1.79 }
+
+      assert_equal(histogram.to_h, key => val)
     end
 
     it 'supports default buckets' do

--- a/test/metric/summary_test.rb
+++ b/test/metric/summary_test.rb
@@ -127,7 +127,10 @@ module PrometheusExporter::Metric
       summary.observe(0.7, name: "bob", family: "skywalker")
       summary.observe(0.99, name: "bob", family: "skywalker")
 
-      assert_equal(summary.to_h, { name: "bob", family: "skywalker" } => { "count" => 3, "sum" => 1.79 })
+      key = { name: "bob", family: "skywalker" }
+      val = { "count" => 3, "sum" => 1.79 }
+
+      assert_equal(summary.to_h, key => val)
     end
 
     it "can correctly remove data" do
@@ -140,7 +143,10 @@ module PrometheusExporter::Metric
 
       summary.remove(name: "jane", family: "skywalker")
 
-      assert_equal(summary.to_h, { name: "bob", family: "skywalker" } => { "count" => 3, "sum" => 1.79 })
+      key = { name: "bob", family: "skywalker" }
+      val = { "count" => 3, "sum" => 1.79 }
+
+      assert_equal(summary.to_h, key => val)
     end
   end
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -102,7 +102,6 @@ class PrometheusExporterMiddlewareTest < Minitest::Test
     redis.call("PING") # => "PONG"
     redis.call("PING") # => "PONG"
     results = PrometheusExporter::Instrumentation::MethodProfiler.stop
-    # redis client injects a HELLO preamble on reconnection, so we will see more than 2
     assert(2, results[:redis][:calls])
 
     assert_equal(2, RedisValidationMiddleware.call_calls)

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -127,7 +127,6 @@ class PrometheusExporterMiddlewareTest < Minitest::Test
     assert_equal(1, RedisValidationMiddleware.call_pipelined_calls)
 
     results = PrometheusExporter::Instrumentation::MethodProfiler.stop
-    # redis client injects a HELLO preamble on reconnection, so we will see more than 2
     assert_equal(1, results[:redis][:calls])
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,35 @@ module TestingMod
   end
 end
 
+module RedisValidationMiddleware
+  def self.reset!
+    @@call_calls = 0
+    @@call_pipelined_calls = 0
+  end
+
+  def self.call_calls
+    @@call_calls || 0
+  end
+
+  def self.call_pipelined_calls
+    @@call_pipelined_calls || 0
+  end
+
+  def call(command, _config)
+    @@call_calls ||= 0
+    @@call_calls += 1
+    super
+  end
+
+  def call_pipelined(command, _config)
+    @@call_pipelined_calls ||= 0
+    @@call_pipelined_calls += 1
+    super
+  end
+end
+
 RedisClient::Middlewares.prepend(TestingMod)
+RedisClient.register(RedisValidationMiddleware)
 
 class TestHelper
   def self.wait_for(time, &blk)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,40 @@ require "prometheus_exporter"
 
 require "minitest/autorun"
 
+require "redis"
+
+module TestingMod
+  class FakeConnection
+    def call_pipelined(_, _)
+    end
+    def call(_, _)
+    end
+    def connected?
+      true
+    end
+    def revalidate
+    end
+    def read_timeout=(v)
+    end
+    def write_timeout=(v)
+    end
+  end
+
+  def connect(_config)
+    FakeConnection.new
+  end
+
+  def call(command, _config)
+    super
+  end
+
+  def call_pipelined(command, _config)
+    super
+  end
+end
+
+RedisClient::Middlewares.prepend(TestingMod)
+
 class TestHelper
   def self.wait_for(time, &blk)
     (time / 0.001).to_i.times do


### PR DESCRIPTION
Redis 5 gem introduces redis_client as the low level transport method

We no longer patch Redis gem if we detect it is version 5 and above and
instead use the supported middleware interface to patch it.
