### PR TITLE
Fix MethodProfiler to preserve the target class behavior

### DIFF
--- a/lib/prometheus_exporter/instrumentation/method_profiler.rb
+++ b/lib/prometheus_exporter/instrumentation/method_profiler.rb
@@ -64,9 +64,9 @@ class PrometheusExporter::Instrumentation::MethodProfiler
   end
 
   def self.patch_using_prepend(klass, methods, name)
-    prepend_instument = Module.new
-    define_methods_on_module(klass, methods, name)
-    klass.prepend(prepend_instument)
+    prepend_instrument = Module.new
+    define_methods_on_module(prepend_instrument, methods, name)
+    klass.prepend(prepend_instrument)
   end
 
   def self.patch_using_alias_method(klass, methods, name)

--- a/test/instrumentation/method_profiler_test.rb
+++ b/test/instrumentation/method_profiler_test.rb
@@ -16,10 +16,8 @@ class PrometheusInstrumentationMethodProfilerTest < Minitest::Test
     end
   end
 
-  def setup
-    PrometheusExporter::Instrumentation::MethodProfiler.patch SomeClassPatchedUsingAliasMethod, [:some_method], :test, instrument: :alias_method
-    PrometheusExporter::Instrumentation::MethodProfiler.patch SomeClassPatchedUsingPrepend, [:some_method], :test, instrument: :prepend
-  end
+  PrometheusExporter::Instrumentation::MethodProfiler.patch SomeClassPatchedUsingAliasMethod, [:some_method], :test, instrument: :alias_method
+  PrometheusExporter::Instrumentation::MethodProfiler.patch SomeClassPatchedUsingPrepend, [:some_method], :test, instrument: :prepend
 
   def test_alias_method_source_location
     file, line = SomeClassPatchedUsingAliasMethod.instance_method(:some_method).source_location

--- a/test/instrumentation/method_profiler_test.rb
+++ b/test/instrumentation/method_profiler_test.rb
@@ -27,9 +27,17 @@ class PrometheusInstrumentationMethodProfilerTest < Minitest::Test
     assert_equal 'def #{method_name}(*args, &blk)', source
   end
 
+  def test_alias_method_preserves_behavior
+    assert_equal 'Hello, world', SomeClassPatchedUsingAliasMethod.new.some_method
+  end
+
   def test_prepend_source_location
     file, line = SomeClassPatchedUsingPrepend.instance_method(:some_method).source_location
     source = File.read(file).lines[line - 1].strip
     assert_equal 'def #{method_name}(*args, &blk)', source
+  end
+
+  def test_prepend_preserves_behavior
+    assert_equal 'Hello, world', SomeClassPatchedUsingPrepend.new.some_method
   end
 end


### PR DESCRIPTION
I suspect that the change introduced by https://github.com/discourse/prometheus_exporter/pull/250/files#diff-cb9a335ee1d17a77e55d1bc374c4c76ebbf05e6b84de4ce41f1fbc560bda41b7R68 applies the patch to the original class.
It causes NoMethodError and breaks the bahavior when the original class doesn't have super class.

I think this will fix https://github.com/discourse/prometheus_exporter/issues/252 .