### PR TITLE
FIX: sidekiq stats collector memory leak

### DIFF
--- a/lib/prometheus_exporter/server/sidekiq_stats_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_stats_collector.rb
@@ -40,6 +40,9 @@ module PrometheusExporter::Server
     end
 
     def collect(object)
+      now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      object['created_at'] = now
+      sidekiq_metrics.delete_if { |metric| metric['created_at'] + MAX_SIDEKIQ_METRIC_AGE < now }
       sidekiq_metrics << object
     end
   end

--- a/test/server/sidekiq_stats_collector_test.rb
+++ b/test/server/sidekiq_stats_collector_test.rb
@@ -40,4 +40,52 @@ class PrometheusSidekiqStatsCollectorTest < Minitest::Test
     ]
     assert_equal expected, metrics.map(&:metric_text)
   end
+
+  def test_only_fresh_metrics_are_collected
+    Process.stub(:clock_gettime, 1.0) do
+      collector.collect(
+        'stats' => {
+          'dead_size' => 1,
+          'enqueued' => 2,
+          'failed' => 3,
+          'processed' => 4,
+          'processes_size' => 5,
+          'retry_size' => 6,
+          'scheduled_size' => 7,
+          'workers_size' => 8,
+        }
+      )
+    end
+
+    Process.stub(:clock_gettime, 2.0 + PrometheusExporter::Server::SidekiqStatsCollector::MAX_SIDEKIQ_METRIC_AGE) do
+      collector.collect(
+        'stats' => {
+          'dead_size' => 2,
+          'enqueued' => 3,
+          'failed' => 4,
+          'processed' => 5,
+          'processes_size' => 6,
+          'retry_size' => 7,
+          'scheduled_size' => 8,
+          'workers_size' => 9,
+        }
+      )
+
+      metrics = collector.metrics
+      expected = [
+        "sidekiq_stats_dead_size 2",
+        "sidekiq_stats_enqueued 3",
+        "sidekiq_stats_failed 4",
+        "sidekiq_stats_processed 5",
+        "sidekiq_stats_processes_size 6",
+        "sidekiq_stats_retry_size 7",
+        "sidekiq_stats_scheduled_size 8",
+        "sidekiq_stats_workers_size 9"
+      ]
+      assert_equal expected, metrics.map(&:metric_text)
+
+      assert_equal 1, collector.sidekiq_metrics.size
+    end
+  end
+
 end


### PR DESCRIPTION
We also experienced the problem explained in #240 , in which metrics present in the `sidekiq` stats collector started to grow and saturated the process (used all CPU assigned to it).

This PR aims to clean old metrics, as [sidekiq_queue_collector.rb](https://github.com/discourse/prometheus_exporter/blob/main/lib/prometheus_exporter/server/sidekiq_queue_collector.rb) does.