### PR TITLE
Use specified labels over default labels in merge conflicts

### DIFF
--- a/lib/prometheus_exporter/metric/base.rb
+++ b/lib/prometheus_exporter/metric/base.rb
@@ -75,7 +75,7 @@ module PrometheusExporter::Metric
     end
 
     def labels_text(labels)
-      labels = (labels || {}).merge(Base.default_labels)
+      labels = Base.default_labels.merge(labels || {})
       if labels && labels.length > 0
         s = labels.map do |key, value|
           value = value.to_s

--- a/test/metric/base_test.rb
+++ b/test/metric/base_test.rb
@@ -43,7 +43,23 @@ module PrometheusExporter::Metric
       text = <<~TEXT
         # HELP a_counter my amazing counter
         # TYPE a_counter counter
-        a_counter{baz="bar",foo="bar"} 2
+        a_counter{foo="bar",baz="bar"} 2
+        a_counter{foo="bar"} 1
+      TEXT
+
+      assert_equal(counter.to_prometheus_text, text)
+    end
+
+    it "uses specified labels over default labels when there is conflict" do
+      Base.default_labels = { foo: "bar" }
+
+      counter.observe(2, foo: "baz")
+      counter.observe
+
+      text = <<~TEXT
+        # HELP a_counter my amazing counter
+        # TYPE a_counter counter
+        a_counter{foo="baz"} 2
         a_counter{foo="bar"} 1
       TEXT
 


### PR DESCRIPTION
Currently, `PrometheusExporter::Metrics::Base.default_labels` will overwrite the labels specified when observing metrics in the `labels_text` output. This isn't ideal in scenarios where you want to specify a label key/value pair that doesn't match the default labels.

In this pull request, I've swapped the ordering of the merge such that we merge the specified labels into the default labels, meaning the specified labels have precedence over the default ones.