### PR TITLE
Allow binding server to both ipv4/ipv6 interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,9 @@ prometheus_exporter -p 8080 \
                     --prefix 'foo_'
 ```
 
+You can use `-b` option to bind the `prometheus_exporter` web server to any IPv4 interface with `-b 0.0.0.0`, 
+any IPv6 interface with `-b ::`, or `-b ANY` to any IPv4/IPv6 interfaces available on your host system.
+
 #### Enabling Basic Authentication
 
 If you desire authentication on your `/metrics` route, you can enable basic authentication with the `--auth` option.

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -44,6 +44,11 @@ module PrometheusExporter::Server
 
       @logger.info "Using Basic Authentication via #{@auth}" if @verbose && @auth
 
+      if @bind == "ALL"
+        @logger.info "Listening on both 0.0.0.0/:: network interfaces"
+        @bind = nil
+      end
+
       @server = WEBrick::HTTPServer.new(
         Port: @port,
         BindAddress: @bind,

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -44,7 +44,7 @@ module PrometheusExporter::Server
 
       @logger.info "Using Basic Authentication via #{@auth}" if @verbose && @auth
 
-      if @bind == "ALL"
+      if %w(ALL ANY).include?(@bind)
         @logger.info "Listening on both 0.0.0.0/:: network interfaces"
         @bind = nil
       end


### PR DESCRIPTION
Starting `prometheus_exporter -v -b ALL -p 8080` will include the log message:

```
2022-12-26 16:54:44 -0600 Starting prometheus exporter on ALL:8080
[2022-12-26 16:54:44] INFO  Listening on both 0.0.0.0/:: network interfaces
[2022-12-26 16:54:44] INFO  WEBrick 1.7.0
[2022-12-26 16:54:44] INFO  ruby 2.7.2 (2020-10-01) [arm64-darwin21]
[2022-12-26 16:54:44] INFO  WEBrick::HTTPServer#start: pid=86361 port=8080
```

netstat: 

```
$ netstat -an -ptcp | grep LISTEN | grep 8080
tcp4       0      0  *.8080                 *.*                    LISTEN
tcp6       0      0  *.8080                 *.*                    LISTEN
```