### PR TITLE
Handle stale sidekiq queue and process metrics

### DIFF
--- a/lib/prometheus_exporter/server/metrics_container.rb
+++ b/lib/prometheus_exporter/server/metrics_container.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module PrometheusExporter::Server
+  class MetricsContainer
+    METRIC_MAX_AGE = 60
+    METRIC_EXPIRE_ATTR = "_expire_at"
+
+    attr_reader :data, :ttl
+
+    def initialize(ttl: METRIC_MAX_AGE, expire_attr: METRIC_EXPIRE_ATTR)
+      @data        = []
+      @ttl         = ttl
+      @expire_attr = expire_attr
+    end
+
+    def <<(obj)
+      now = get_time
+      obj[@expire_attr] = now + @ttl
+
+      @data << obj
+      expire(time: now)
+      @data
+    end
+
+    def [](key)
+      @data.tap { expire }[key]
+    end
+
+    def size(&blk) ; wrap_expire(:size, &blk) ; end
+    def map(&blk)  ; wrap_expire(:map, &blk)  ; end
+    def each(&blk) ; wrap_expire(:each, &blk) ; end
+
+    def expire(time: nil)
+      time ||= get_time
+      @data.delete_if { |metric| metric[@expire_attr] < time }
+    end
+
+    private
+
+    def get_time
+      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    end
+
+    def wrap_expire(method_name, &blk)
+      expire.send(method_name, &blk)
+    end
+  end
+end

--- a/lib/prometheus_exporter/server/metrics_container.rb
+++ b/lib/prometheus_exporter/server/metrics_container.rb
@@ -50,7 +50,8 @@ module PrometheusExporter::Server
     end
 
     def wrap_expire(method_name, &blk)
-      expire.send(method_name, &blk)
+      expire
+      @data.public_send(method_name, &blk)
     end
   end
 end

--- a/lib/prometheus_exporter/server/metrics_container.rb
+++ b/lib/prometheus_exporter/server/metrics_container.rb
@@ -26,9 +26,17 @@ module PrometheusExporter::Server
       @data.tap { expire }[key]
     end
 
-    def size(&blk) ; wrap_expire(:size, &blk) ; end
-    def map(&blk)  ; wrap_expire(:map, &blk)  ; end
-    def each(&blk) ; wrap_expire(:each, &blk) ; end
+    def size(&blk)
+      wrap_expire(:size, &blk)
+    end
+
+    def map(&blk)
+      wrap_expire(:map, &blk)
+    end
+
+    def each(&blk)
+      wrap_expire(:each, &blk)
+    end
 
     def expire(time: nil)
       time ||= get_time

--- a/lib/prometheus_exporter/server/sidekiq_process_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_process_collector.rb
@@ -12,7 +12,7 @@ module PrometheusExporter::Server
     attr_reader :sidekiq_metrics, :gauges
 
     def initialize
-      @sidekiq_metrics = []
+      @sidekiq_metrics = MetricsContainer.new(ttl: MAX_SIDEKIQ_METRIC_AGE)
       @gauges = {}
     end
 
@@ -21,7 +21,7 @@ module PrometheusExporter::Server
     end
 
     def metrics
-      clear_stale_metrics(reset_gauges: true)
+      SIDEKIQ_PROCESS_GAUGES.each_key { |name| gauges[name]&.reset! }
 
       sidekiq_metrics.map do |metric|
         labels = metric.fetch('labels', {})
@@ -37,23 +37,7 @@ module PrometheusExporter::Server
     end
 
     def collect(object)
-      now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-      clear_stale_metrics(time: now)
-
-      process = object['process']
-      process["created_at"] = now
-      sidekiq_metrics << process
-    end
-
-    private
-
-    def clear_stale_metrics(time: nil, reset_gauges: false)
-      time ||= ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-      sidekiq_metrics.delete_if { |metric| metric['created_at'] + MAX_SIDEKIQ_METRIC_AGE < time }
-
-      if reset_gauges
-        SIDEKIQ_PROCESS_GAUGES.each_key { |name| gauges[name]&.reset! }
-      end
+      @sidekiq_metrics << object["process"]
     end
   end
 end

--- a/lib/prometheus_exporter/server/type_collector.rb
+++ b/lib/prometheus_exporter/server/type_collector.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "prometheus_exporter/server/metrics_container"
+
 module PrometheusExporter::Server
   class TypeCollector
     def type

--- a/test/server/metrics_container_test.rb
+++ b/test/server/metrics_container_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+require 'prometheus_exporter/server'
+require 'prometheus_exporter/instrumentation'
+require 'prometheus_exporter/server/metrics_container'
+
+class PrometheusMetricsContainerTest < Minitest::Test
+  def stub_process_clock_time(value, &blk)
+    Process.stub(:clock_gettime, value, &blk)
+  end
+
+  def metrics
+    @metrics ||= PrometheusExporter::Server::MetricsContainer.new
+  end
+
+  def test_container_with_expiration
+    stub_process_clock_time(1.0) do
+      metrics << { key: "value" }
+      assert_equal 1, metrics.size
+      assert_equal 61.0, metrics[0]["_expire_at"]
+    end
+
+    stub_process_clock_time(61.0) do
+      metrics << { key: "value2" }
+      assert_equal 2, metrics.size
+      assert_equal ["value", "value2"], metrics.map { |v| v[:key] }
+      assert_equal 61.0, metrics[0]["_expire_at"]
+      assert_equal 121.0, metrics[1]["_expire_at"]
+    end
+
+    stub_process_clock_time(62.0) do
+      metrics << { key: "value3" }
+      assert_equal 2, metrics.size
+      assert_equal ["value2", "value3"], metrics.map { |v| v[:key] }
+      assert_equal 121.0, metrics[0]["_expire_at"]
+      assert_equal 122.0, metrics[1]["_expire_at"]
+    end
+
+    stub_process_clock_time(1000.0) do
+      # check raw data before expiry event
+      assert_equal 2, metrics.data.size
+
+      num = 0
+      metrics.each { |m| num += 1 }
+      assert_equal 0, num
+      assert_equal 0, metrics.size
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a few handling bits for dealing with stale sidekiq metics.
Root cause of the issue is described in #261.