### PR TITLE
FIX: Memory leaks in unicorn + puma collectors

### DIFF
--- a/lib/prometheus_exporter/server/puma_collector.rb
+++ b/lib/prometheus_exporter/server/puma_collector.rb
@@ -54,6 +54,10 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
+      now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+
+      obj["created_at"] = now
+      @puma_metrics.delete_if { |m| m["created_at"] + MAX_PUMA_METRIC_AGE < now }
       @puma_metrics << obj
     end
   end


### PR DESCRIPTION
This cherry-picks an old commit that somehow got removed/overwritten. See related discussion at: https://github.com/discourse/prometheus_exporter/issues/275