### PR TITLE
Remove post install message

### DIFF
--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |spec|
   spec.homepage             = "https://github.com/discourse/prometheus_exporter"
   spec.license              = "MIT"
 
-  spec.post_install_message = "prometheus_exporter will only bind to localhost by default as of v0.5"
-
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features|bin)/})
   end


### PR DESCRIPTION
v0.5 has been released in 2020, we probably don't need this message anymore :)