### PR TITLE
Get controller labels from controller, not params

### DIFF
--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -60,11 +60,11 @@ class PrometheusExporter::Middleware
   end
 
   def default_labels(env, result)
-    params = env["action_dispatch.request.parameters"]
+    controller_instance = env["action_controller.instance"]
     action = controller = nil
-    if params
-      action = params["action"]
-      controller = params["controller"]
+    if controller_instance
+      action = controller_instance.action_name
+      controller = controller_instance.controller_name
     elsif (cors = env["rack.cors"]) && cors.respond_to?(:preflight?) && cors.preflight?
       # if the Rack CORS Middleware identifies the request as a preflight request,
       # the stack doesn't get to the point where controllers/actions are defined


### PR DESCRIPTION
prometheus_exporter currently reads the controller and action label from action_dispatch.request.parameters. This can lead to conflicts, where there's a form parameter called "action", or "controller" which takes precedence over "which controller action is this?".

This can be validated with a curl request to a rails application instrumented with prometheus_exporter:

    curl -v http://127.0.0.1:3000/ --data 'controller=test'

Results in:

    # HELP http_requests_total Total HTTP requests from web app.
    # TYPE http_requests_total counter
    http_requests_total{action="other",controller="test",status="404"} 1

This commit pulls the controller instance from `action_controller.instance`, and then calls the controller_name / action_name methods, which should be accurate even when conflicting form parameters are provided.

I haven't added any new tests for this, but I have tested it locally (by pointing a local rails app at a local copy of the gem, and doing the curl request above). Please let me know if you'd like a test (I might need a hint as to where to put it though).