### PR TITLE
Add marking and sweeping time as Process stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,8 +373,8 @@ end
 | Counter | `major_gc_ops_total`      | Major GC operations by process               |
 | Counter | `minor_gc_ops_total`      | Minor GC operations by process               |
 | Counter | `allocated_objects_total` | Total number of allocated objects by process |
-| Gauge   | `marking_time`            | Marking time spent                           |
-| Gauge   | `sweeping_time`           | Sweeping time spent                          |
+| Gauge   | `marking_time`            | Marking time spent (Ruby 3.3 minimum)        |
+| Gauge   | `sweeping_time`           | Sweeping time spent (Ruby 3.3 minimum)       |
 
 _Metrics marked with * are only collected when `MiniRacer` is defined._
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ end
 | Counter | `major_gc_ops_total`      | Major GC operations by process               |
 | Counter | `minor_gc_ops_total`      | Minor GC operations by process               |
 | Counter | `allocated_objects_total` | Total number of allocated objects by process |
+| Gauge   | `marking_time`            | Marking time spent                           |
+| Gauge   | `sweeping_time`           | Sweeping time spent                          |
 
 _Metrics marked with * are only collected when `MiniRacer` is defined._
 

--- a/lib/prometheus_exporter/instrumentation/process.rb
+++ b/lib/prometheus_exporter/instrumentation/process.rb
@@ -62,6 +62,8 @@ module PrometheusExporter::Instrumentation
       metric[:rss] = rss
     end
 
+    SWEEPING_AND_MARKING = RUBY_VERSION >= "3.3.0"
+
     def collect_gc_stats(metric)
       stat = GC.stat
       metric[:heap_live_slots] = stat[:heap_live_slots]
@@ -71,8 +73,10 @@ module PrometheusExporter::Instrumentation
       metric[:allocated_objects_total] = stat[:total_allocated_objects]
       metric[:malloc_increase_bytes_limit] = stat[:malloc_increase_bytes_limit]
       metric[:oldmalloc_increase_bytes_limit] = stat[:oldmalloc_increase_bytes_limit]
-      metric[:marking_time] = stat[:marking_time]
-      metric[:sweeping_time] = stat[:sweeping_time]
+      if SWEEPING_AND_MARKING
+        metric[:marking_time] = stat[:marking_time]
+        metric[:sweeping_time] = stat[:sweeping_time]
+      end
     end
 
     def collect_v8_stats(metric)

--- a/lib/prometheus_exporter/instrumentation/process.rb
+++ b/lib/prometheus_exporter/instrumentation/process.rb
@@ -71,6 +71,8 @@ module PrometheusExporter::Instrumentation
       metric[:allocated_objects_total] = stat[:total_allocated_objects]
       metric[:malloc_increase_bytes_limit] = stat[:malloc_increase_bytes_limit]
       metric[:oldmalloc_increase_bytes_limit] = stat[:oldmalloc_increase_bytes_limit]
+      metric[:marking_time] = stat[:marking_time]
+      metric[:sweeping_time] = stat[:sweeping_time]
     end
 
     def collect_v8_stats(metric)

--- a/lib/prometheus_exporter/server/process_collector.rb
+++ b/lib/prometheus_exporter/server/process_collector.rb
@@ -16,6 +16,8 @@ module PrometheusExporter::Server
         "Limit before Ruby triggers a GC against current objects (bytes).",
       oldmalloc_increase_bytes_limit:
         "Limit before Ruby triggers a major GC against old objects (bytes).",
+      marking_time: "Time spent in GC marking.",
+      sweeping_time: "Time spent in GC sweeping.",
     }
 
     PROCESS_COUNTERS = {

--- a/test/server/process_collector_test.rb
+++ b/test/server/process_collector_test.rb
@@ -37,7 +37,6 @@ class ProcessCollectorTest < Minitest::Test
 
     assert_equal 12, collector.metrics.size
     assert_equal [
-<<<<<<< HEAD
                    'heap_free_slots{pid="1000",hostname="localhost"} 1000',
                    'heap_live_slots{pid="1000",hostname="localhost"} 1001',
                    'v8_heap_size{pid="1000",hostname="localhost"} 2000',
@@ -45,38 +44,13 @@ class ProcessCollectorTest < Minitest::Test
                    'v8_physical_size{pid="1000",hostname="localhost"} 2003',
                    'v8_heap_count{pid="1000",hostname="localhost"} 2004',
                    'rss{pid="1000",hostname="localhost"} 3000',
+                   'marking_time{pid="1000",hostname="localhost"} 4003',
+                   'sweeping_time{pid="1000",hostname="localhost"} 4004',
                    'major_gc_ops_total{pid="1000",hostname="localhost"} 4000',
                    'minor_gc_ops_total{pid="1000",hostname="localhost"} 4001',
                    'allocated_objects_total{pid="1000",hostname="localhost"} 4002',
                  ],
                  collector_metric_lines
-||||||| parent of 594c218 (Add marking and sweeping time as Process stat)
-      'heap_free_slots{pid="1000",hostname="localhost"} 1000',
-      'heap_live_slots{pid="1000",hostname="localhost"} 1001',
-      'v8_heap_size{pid="1000",hostname="localhost"} 2000',
-      'v8_used_heap_size{pid="1000",hostname="localhost"} 2001',
-      'v8_physical_size{pid="1000",hostname="localhost"} 2003',
-      'v8_heap_count{pid="1000",hostname="localhost"} 2004',
-      'rss{pid="1000",hostname="localhost"} 3000',
-      'major_gc_ops_total{pid="1000",hostname="localhost"} 4000',
-      'minor_gc_ops_total{pid="1000",hostname="localhost"} 4001',
-      'allocated_objects_total{pid="1000",hostname="localhost"} 4002'
-    ], collector_metric_lines
-=======
-      'heap_free_slots{pid="1000",hostname="localhost"} 1000',
-      'heap_live_slots{pid="1000",hostname="localhost"} 1001',
-      'v8_heap_size{pid="1000",hostname="localhost"} 2000',
-      'v8_used_heap_size{pid="1000",hostname="localhost"} 2001',
-      'v8_physical_size{pid="1000",hostname="localhost"} 2003',
-      'v8_heap_count{pid="1000",hostname="localhost"} 2004',
-      'rss{pid="1000",hostname="localhost"} 3000',
-      'marking_time{pid="1000",hostname="localhost"} 4003',
-      'sweeping_time{pid="1000",hostname="localhost"} 4004',
-      'major_gc_ops_total{pid="1000",hostname="localhost"} 4000',
-      'minor_gc_ops_total{pid="1000",hostname="localhost"} 4001',
-      'allocated_objects_total{pid="1000",hostname="localhost"} 4002',
-    ], collector_metric_lines
->>>>>>> 594c218 (Add marking and sweeping time as Process stat)
   end
 
   def test_metrics_deduplication

--- a/test/server/process_collector_test.rb
+++ b/test/server/process_collector_test.rb
@@ -27,14 +27,17 @@ class ProcessCollectorTest < Minitest::Test
       "major_gc_ops_total" => 4000,
       "minor_gc_ops_total" => 4001,
       "allocated_objects_total" => 4002,
+      "marking_time" => 4003,
+      "sweeping_time" => 4004,
     }
   end
 
   def test_metrics_collection
     collector.collect(base_data)
 
-    assert_equal 10, collector.metrics.size
+    assert_equal 12, collector.metrics.size
     assert_equal [
+<<<<<<< HEAD
                    'heap_free_slots{pid="1000",hostname="localhost"} 1000',
                    'heap_live_slots{pid="1000",hostname="localhost"} 1001',
                    'v8_heap_size{pid="1000",hostname="localhost"} 2000',
@@ -47,26 +50,53 @@ class ProcessCollectorTest < Minitest::Test
                    'allocated_objects_total{pid="1000",hostname="localhost"} 4002',
                  ],
                  collector_metric_lines
+||||||| parent of 594c218 (Add marking and sweeping time as Process stat)
+      'heap_free_slots{pid="1000",hostname="localhost"} 1000',
+      'heap_live_slots{pid="1000",hostname="localhost"} 1001',
+      'v8_heap_size{pid="1000",hostname="localhost"} 2000',
+      'v8_used_heap_size{pid="1000",hostname="localhost"} 2001',
+      'v8_physical_size{pid="1000",hostname="localhost"} 2003',
+      'v8_heap_count{pid="1000",hostname="localhost"} 2004',
+      'rss{pid="1000",hostname="localhost"} 3000',
+      'major_gc_ops_total{pid="1000",hostname="localhost"} 4000',
+      'minor_gc_ops_total{pid="1000",hostname="localhost"} 4001',
+      'allocated_objects_total{pid="1000",hostname="localhost"} 4002'
+    ], collector_metric_lines
+=======
+      'heap_free_slots{pid="1000",hostname="localhost"} 1000',
+      'heap_live_slots{pid="1000",hostname="localhost"} 1001',
+      'v8_heap_size{pid="1000",hostname="localhost"} 2000',
+      'v8_used_heap_size{pid="1000",hostname="localhost"} 2001',
+      'v8_physical_size{pid="1000",hostname="localhost"} 2003',
+      'v8_heap_count{pid="1000",hostname="localhost"} 2004',
+      'rss{pid="1000",hostname="localhost"} 3000',
+      'marking_time{pid="1000",hostname="localhost"} 4003',
+      'sweeping_time{pid="1000",hostname="localhost"} 4004',
+      'major_gc_ops_total{pid="1000",hostname="localhost"} 4000',
+      'minor_gc_ops_total{pid="1000",hostname="localhost"} 4001',
+      'allocated_objects_total{pid="1000",hostname="localhost"} 4002',
+    ], collector_metric_lines
+>>>>>>> 594c218 (Add marking and sweeping time as Process stat)
   end
 
   def test_metrics_deduplication
     collector.collect(base_data)
-    assert_equal 10, collector.metrics.size
-    assert_equal 10, collector_metric_lines.size
+    assert_equal 12, collector.metrics.size
+    assert_equal 12, collector_metric_lines.size
 
     collector.collect(base_data)
-    assert_equal 10, collector.metrics.size
-    assert_equal 10, collector_metric_lines.size
+    assert_equal 12, collector.metrics.size
+    assert_equal 12, collector_metric_lines.size
 
     collector.collect(base_data.merge({ "hostname" => "localhost2" }))
-    assert_equal 10, collector.metrics.size
-    assert_equal 20, collector_metric_lines.size
+    assert_equal 12, collector.metrics.size
+    assert_equal 24, collector_metric_lines.size
   end
 
   def test_metrics_expiration
     stub_monotonic_clock(0) do
       collector.collect(base_data)
-      assert_equal 10, collector.metrics.size
+      assert_equal 12, collector.metrics.size
     end
 
     stub_monotonic_clock(max_metric_age + 1) { assert_equal 0, collector.metrics.size }


### PR DESCRIPTION
Add marking and sweeping time as GC stats. It was introduced in https://bugs.ruby-lang.org/issues/19437

I think we should also add `GC.latest_gc_info[:major_by]`. I can do it in another PR.
```diff
--- a/lib/prometheus_exporter/instrumentation/process.rb
+++ b/lib/prometheus_exporter/instrumentation/process.rb
@@ -65,6 +65,7 @@ module PrometheusExporter::Instrumentation
       metric[:allocated_objects_total] = stat[:total_allocated_objects]
       metric[:marking_time] = stat[:marking_time]
       metric[:sweeping_time] = stat[:sweeping_time]
+      metric[:last_major_by] = GC.latest_gc_info[:major_by]
```
We could store it as a last state like kube-state-metrics does for [pod last state](https://github.com/kubernetes/kube-state-metrics/blob/90bd24f27c618ce916db4cd9da34d854d49db5b6/docs/pod-metrics.md?plain=1#L24).
It's a fast method. At the moment it's not possible because gauge are only numeric in prometheus_exporter.

cc @mtparet @byroot