### PR TITLE
Add delayed_jobs_ready to DelayedJobs plugin and collect_by_queue option for GoodJob plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ end
 | Counter | `delayed_jobs_total`                      | Total number of delayed jobs executed                              | `job_name` |
 | Gauge   | `delayed_jobs_enqueued`                   | Number of enqueued delayed jobs                                    | -          |
 | Gauge   | `delayed_jobs_pending`                    | Number of pending delayed jobs                                     | -          |
+| Gauge   | `delayed_jobs_ready`                      | Number of ready delayed jobs                                       | -          |
 | Counter | `delayed_failed_jobs_total`               | Total number failed delayed jobs executed                          | `job_name` |
 | Counter | `delayed_jobs_max_attempts_reached_total` | Total number of delayed jobs that reached max attempts             | -          |
 | Summary | `delayed_job_duration_seconds_summary`    | Summary of the time it takes jobs to execute                       | `status`   |
@@ -884,7 +885,7 @@ prometheus_exporter -p 8080 \
                     --prefix 'foo_'
 ```
 
-You can use `-b` option to bind the `prometheus_exporter` web server to any IPv4 interface with `-b 0.0.0.0`, 
+You can use `-b` option to bind the `prometheus_exporter` web server to any IPv4 interface with `-b 0.0.0.0`,
 any IPv6 interface with `-b ::`, or `-b ANY` to any IPv4/IPv6 interfaces available on your host system.
 
 #### Enabling Basic Authentication

--- a/README.md
+++ b/README.md
@@ -640,6 +640,9 @@ installation, you'll need to start the instrumentation:
 # e.g. config/initializers/good_job.rb
 require 'prometheus_exporter/instrumentation'
 PrometheusExporter::Instrumentation::GoodJob.start
+
+# or, to collect metrics labelled by their queue name
+PrometheusExporter::Instrumentation::GoodJob.start(collect_by_queue: true)
 ```
 
 #### Metrics collected by GoodJob Instrumentation

--- a/lib/prometheus_exporter/instrumentation/delayed_job.rb
+++ b/lib/prometheus_exporter/instrumentation/delayed_job.rb
@@ -52,7 +52,7 @@ module PrometheusExporter::Instrumentation
         max_attempts: max_attempts,
         enqueued: enqueued_count,
         pending: pending_count,
-        ready_count: ready_count
+        ready: ready_count
       )
     end
   end

--- a/lib/prometheus_exporter/instrumentation/delayed_job.rb
+++ b/lib/prometheus_exporter/instrumentation/delayed_job.rb
@@ -4,8 +4,6 @@ module PrometheusExporter::Instrumentation
   class DelayedJob
     JOB_CLASS_REGEXP = %r{job_class: (\w+:{0,2})+}.freeze
 
-    RuntimeMetric = Struct.new(:max_attempts, :enqueued_count, :pending_count, :ready_count)
-
     class << self
       def register_plugin(client: nil)
         instrumenter = self.new(client: client)

--- a/lib/prometheus_exporter/instrumentation/delayed_job.rb
+++ b/lib/prometheus_exporter/instrumentation/delayed_job.rb
@@ -17,6 +17,7 @@ module PrometheusExporter::Instrumentation
               max_attempts = Delayed::Worker.max_attempts
               enqueued_count = Delayed::Job.where(queue: job.queue).count
               pending_count = Delayed::Job.where(attempts: 0, locked_at: nil, queue: job.queue).count
+              # It may be necessary to coallesce the run_at time with created_at timestamp to get a more accurate count
               ready_count = Delayed::Job.where(queue: job.queue, run_at: ..Time.current).count
               instrumenter.call(job, max_attempts, enqueued_count, pending_count, ready_count, *args, &block)
             end

--- a/lib/prometheus_exporter/instrumentation/good_job.rb
+++ b/lib/prometheus_exporter/instrumentation/good_job.rb
@@ -3,27 +3,32 @@
 # collects stats from GoodJob
 module PrometheusExporter::Instrumentation
   class GoodJob < PeriodicStats
-    def self.start(client: nil, frequency: 30)
+    COUNT_BY_QUEUE = ->(collection) { collection.group(:queue_name).size }
+    COUNT_ALL = ->(collection) { collection.size }
+
+    def self.start(client: nil, frequency: 30, collect_by_queue: false)
       good_job_collector = new
       client ||= PrometheusExporter::Client.default
 
       worker_loop do
-        client.send_json(good_job_collector.collect)
+        client.send_json(good_job_collector.collect(collect_by_queue))
       end
 
       super
     end
 
-    def collect
+    def collect(by_queue = false)
+      count_method = by_queue ? COUNT_BY_QUEUE : COUNT_ALL
       {
         type: "good_job",
-        scheduled: ::GoodJob::Job.scheduled.size,
-        retried: ::GoodJob::Job.retried.size,
-        queued: ::GoodJob::Job.queued.size,
-        running: ::GoodJob::Job.running.size,
-        finished: ::GoodJob::Job.finished.size,
-        succeeded: ::GoodJob::Job.succeeded.size,
-        discarded: ::GoodJob::Job.discarded.size
+        by_queue: by_queue,
+        scheduled: ::GoodJob::Job.scheduled.yield_self(&count_method),
+        retried: ::GoodJob::Job.retried.yield_self(&count_method),
+        queued: ::GoodJob::Job.queued.yield_self(&count_method),
+        running: ::GoodJob::Job.running.yield_self(&count_method),
+        finished: ::GoodJob::Job.finished.yield_self(&count_method),
+        succeeded: ::GoodJob::Job.succeeded.yield_self(&count_method),
+        discarded: ::GoodJob::Job.discarded.yield_self(&count_method)
       }
     end
   end

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -13,6 +13,7 @@ module PrometheusExporter::Server
       @delayed_job_attempts_summary = nil
       @delayed_jobs_enqueued = nil
       @delayed_jobs_pending = nil
+      @delayed_jobs_ready = nil
     end
 
     def type
@@ -36,6 +37,7 @@ module PrometheusExporter::Server
       @delayed_job_attempts_summary.observe(obj["attempts"], counter_labels) if obj["success"]
       @delayed_jobs_enqueued.observe(obj["enqueued"], gauge_labels)
       @delayed_jobs_pending.observe(obj["pending"], gauge_labels)
+      @delayed_jobs_ready.observe(obj["ready"], gauge_labels)
     end
 
     def metrics
@@ -72,6 +74,11 @@ module PrometheusExporter::Server
         @delayed_jobs_pending =
         PrometheusExporter::Metric::Gauge.new(
           "delayed_jobs_pending", "Number of pending delayed jobs.")
+
+        @delayed_jobs_ready =
+        PrometheusExporter::Metric::Gauge.new(
+          "delayed_jobs_ready", "Number of ready delayed jobs."
+        )
 
         @delayed_failed_jobs_total =
         PrometheusExporter::Metric::Counter.new(

--- a/lib/prometheus_exporter/server/delayed_job_collector.rb
+++ b/lib/prometheus_exporter/server/delayed_job_collector.rb
@@ -44,7 +44,7 @@ module PrometheusExporter::Server
       if @delayed_jobs_total
         [@delayed_job_duration_seconds, @delayed_job_latency_seconds_total, @delayed_jobs_total, @delayed_failed_jobs_total,
          @delayed_jobs_max_attempts_reached_total, @delayed_job_duration_seconds_summary, @delayed_job_attempts_summary,
-         @delayed_jobs_enqueued, @delayed_jobs_pending]
+         @delayed_jobs_enqueued, @delayed_jobs_pending, @delayed_jobs_ready]
       else
         []
       end

--- a/lib/prometheus_exporter/server/good_job_collector.rb
+++ b/lib/prometheus_exporter/server/good_job_collector.rb
@@ -23,28 +23,9 @@ module PrometheusExporter::Server
     end
 
     def metrics
-      return [] if good_job_metrics.length == 0
+      return [] if good_job_metrics.empty?
 
-      good_job_metrics.map do |metric|
-        labels = metric.fetch("custom_labels", {})
-
-        GOOD_JOB_GAUGES.map do |name, help|
-          value = metric[name.to_s]
-
-          if value
-            gauge = gauges[name] ||= PrometheusExporter::Metric::Gauge.new("good_job_#{name}", help)
-
-            if metric["by_queue"]
-              value.each do |queue_name, count|
-                gauge.observe(count, labels.merge(queue_name: queue_name))
-              end
-            else
-              gauge.observe(value, labels)
-            end
-          end
-        end
-      end
-
+      good_job_metrics.each(&method(:process_metric))
       gauges.values
     end
 
@@ -55,5 +36,24 @@ module PrometheusExporter::Server
     private
 
     attr_reader :good_job_metrics, :gauges
+
+    def process_metric(metric)
+      labels = metric.fetch("custom_labels", {})
+
+      GOOD_JOB_GAUGES.each do |name, help|
+        next unless (value = metric[name.to_s])
+
+        gauge = gauges[name] ||= PrometheusExporter::Metric::Gauge.new("good_job_#{name}", help)
+        observe_metric(gauge, metric, labels, value)
+      end
+    end
+
+    def observe_metric(gauge, metric, labels, value)
+      if metric["by_queue"]
+        value.each { |queue_name, count| gauge.observe(count, labels.merge(queue_name: queue_name)) }
+      else
+        gauge.observe(value, labels)
+      end
+    end
   end
 end

--- a/lib/prometheus_exporter/server/good_job_collector.rb
+++ b/lib/prometheus_exporter/server/good_job_collector.rb
@@ -23,7 +23,7 @@ module PrometheusExporter::Server
     end
 
     def metrics
-      return [] if good_job_metrics.empty?
+      return [] if good_job_metrics.length.zero?
 
       good_job_metrics.each(&method(:process_metric))
       gauges.values

--- a/lib/prometheus_exporter/server/good_job_collector.rb
+++ b/lib/prometheus_exporter/server/good_job_collector.rb
@@ -33,7 +33,14 @@ module PrometheusExporter::Server
 
           if value
             gauge = gauges[name] ||= PrometheusExporter::Metric::Gauge.new("good_job_#{name}", help)
-            gauge.observe(value, labels)
+
+            if metric["by_queue"]
+              value.each do |queue_name, count|
+                gauge.observe(count, labels.merge(queue_name: queue_name))
+              end
+            else
+              gauge.observe(value, labels)
+            end
           end
         end
       end

--- a/lib/prometheus_exporter/server/metrics_container.rb
+++ b/lib/prometheus_exporter/server/metrics_container.rb
@@ -2,6 +2,8 @@
 
 module PrometheusExporter::Server
   class MetricsContainer
+    # Since MetricsContainer defines #each, we can include Enumerable
+    include Enumerable
     METRIC_MAX_AGE = 60
     METRIC_EXPIRE_ATTR = "_expire_at"
 
@@ -33,10 +35,6 @@ module PrometheusExporter::Server
       wrap_expire(:size, &blk)
     end
     alias_method :length, :size
-
-    def map(&blk)
-      wrap_expire(:map, &blk)
-    end
 
     def each(&blk)
       wrap_expire(:each, &blk)

--- a/lib/prometheus_exporter/server/metrics_container.rb
+++ b/lib/prometheus_exporter/server/metrics_container.rb
@@ -2,8 +2,6 @@
 
 module PrometheusExporter::Server
   class MetricsContainer
-    # Since MetricsContainer defines #each, we can include Enumerable
-    include Enumerable
     METRIC_MAX_AGE = 60
     METRIC_EXPIRE_ATTR = "_expire_at"
 
@@ -38,6 +36,10 @@ module PrometheusExporter::Server
 
     def each(&blk)
       wrap_expire(:each, &blk)
+    end
+
+    def map(&blk)
+      wrap_expire(:map, &blk)
     end
 
     def expire(time: nil, new_metric: nil)


### PR DESCRIPTION
This PR was born out of metric gathering for our auto-scaling needs as we're migrating hosting platforms and mid-migration of queue libraries.

This PR adds a new metric to the DelayedJobs plugin - "delayed_jobs_ready". This can be thought of as all of the jobs whose `run_at < now()`. We needed this metric and not queued or pending since those included all of our jobs which could be days, weeks, or months out.

This PR also adds the ability to view GoodJob metrics sliced by queue, similar to the DelayedJobs plugin. It's fairly self-explanatory why scaling queue workers based off how many jobs are enqueued in a given queue may be beneficial. 