### PR TITLE
Fix Github Actions workflow for publish_docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         activerecord: [60, 61, 70]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      new_version_published: ${{ steps.release.outputs.new_version_published }}
+      new_version_published: ${{ steps.release.outputs.new_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Release gem
         id: release
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
Hi 👋 

This PR fixes 2 issues with the current workflow:
- Use v4 of the checkout action to remove the deprecation warnings about nodejs12
- Fix a typo in the output of the publish-rubygems-action. In the action it uses `new_version` as output (src: https://github.com/discourse/publish-rubygems-action/blob/v2/entrypoint.sh#L25) but we were checking on `new_version_published`. This meant the if statement for the `publish_docker` job was always false.

It's not that easy to test, but I tested this out on my fork (with some workarounds) and the `publish_docker` job triggered now successfully: https://github.com/pcallewaert/prometheus_exporter/actions/runs/7637020510

This should fix https://github.com/discourse/prometheus_exporter/issues/301