### PR TITLE
Support malloc / oldmalloc increase bytes limit GC stat

### DIFF
--- a/lib/prometheus_exporter/instrumentation/process.rb
+++ b/lib/prometheus_exporter/instrumentation/process.rb
@@ -63,6 +63,8 @@ module PrometheusExporter::Instrumentation
       metric[:major_gc_ops_total] = stat[:major_gc_count]
       metric[:minor_gc_ops_total] = stat[:minor_gc_count]
       metric[:allocated_objects_total] = stat[:total_allocated_objects]
+      metric[:malloc_increase_bytes_limit] = stat[:malloc_increase_bytes_limit]
+      metric[:oldmalloc_increase_bytes_limit] = stat[:oldmalloc_increase_bytes_limit]
     end
 
     def collect_v8_stats(metric)

--- a/lib/prometheus_exporter/server/process_collector.rb
+++ b/lib/prometheus_exporter/server/process_collector.rb
@@ -13,6 +13,8 @@ module PrometheusExporter::Server
       v8_physical_size: "Physical size consumed by V8 heaps.",
       v8_heap_count: "Number of V8 contexts running.",
       rss: "Total RSS used by process.",
+      malloc_increase_bytes_limit: 'Limit before Ruby triggers a GC against current objects (bytes).',
+      oldmalloc_increase_bytes_limit: 'Limit before Ruby triggers a major GC against old objects (bytes).'
     }
 
     PROCESS_COUNTERS = {


### PR DESCRIPTION
This PR adds support for Ruby GC statistic metrics `malloc_increase_bytes_limit` and `oldmalloc_increase_bytes_limit`. These metrics are useful in determining malloc limits for GC tuning, preventing unnecessary limit threshold recalculations and expansion.

We use these values from Production to tune `RUBY_GC_MALLOC_LIMIT` and `RUBY_GC_OLDMALLOC_LIMIT` accordingly.

We see that appropriate tuning of these metrics can help to alleviate immediate cold start / reboot request latency in our application.

see also: https://blog.appsignal.com/2021/11/17/practical-garbage-collection-tuning-in-ruby.html
see also: https://engineering.appfolio.com/appfolio-engineering/2018/6/27/ruby-memory-environment-variables-simpler-than-they-look