### PR TITLE
Validate naming

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -65,4 +65,25 @@ class PrometheusExporterTest < Minitest::Test
 
     assert_includes(logs.string, "dropping message cause queue is full")
   end
+
+  def test_invalid_naming
+    client = PrometheusExporter::Client.new(custom_labels: {"label" => 1})
+
+    refute_same(false, client.send_json({}))
+    refute_same(false, client.send_json({name: "valid_name"}))
+    refute_same(false, client.send_json({name: "__valid_name"}))
+    refute_same(false, client.send_json({name: "__valid_name_1"}))
+    refute_same(false, client.send_json({name: "__valid_name_1", custom_labels: {"valid_name" => "value"}}))
+    refute_same(false, client.send_json({name: "valid_name", custom_labels: {"_valid_name" => "value"}}))
+
+    assert_equal(false, client.send_json({name: "invalid-name"}))
+    assert_equal(false, client.send_json({name: "valid_name", custom_labels: {"__invalid_name" => "value"}}))
+    assert_equal(false, client.send_json({name: "valid_name", custom_labels: {"invalid-name" => "value"}}))
+
+    client.custom_labels = {"__invalid_name" => "value"}
+    assert_equal(false, client.send_json({}))
+
+    client.custom_labels = {"invalid-name" => "value"}
+    assert_equal(false, client.send_json({}))
+  end
 end


### PR DESCRIPTION
👋 everyone,

Related to https://github.com/discourse/prometheus_exporter/issues/292 I've opened an MR that validates the [naming expectations](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels) of Prometheus before sending the event.

I'm returning `false` for now but I am open to ideas as to the best way to handle this. 