### PR TITLE
Add counter warmup option

### DIFF
--- a/bin/prometheus_exporter
+++ b/bin/prometheus_exporter
@@ -71,6 +71,10 @@ def run
     opt.on('--logger-path PATH', String, '(optional) Path to file for logger output. Defaults to STDERR') do |o|
       options[:logger_path] = o
     end
+
+    opt.on('--counter-warmup', "Automate initialization of counter values to 0") do |o|
+      options[:counter_warmup] = true
+    end
   end.parse!
 
   logger = Logger.new(options[:logger_path])

--- a/lib/prometheus_exporter/metric/counter.rb
+++ b/lib/prometheus_exporter/metric/counter.rb
@@ -2,6 +2,17 @@
 
 module PrometheusExporter::Metric
   class Counter < Base
+
+    @counter_warmup_enabled = nil if !defined?(@counter_warmup_enabled)
+
+    def self.counter_warmup=(enabled)
+      @counter_warmup_enabled = enabled
+    end
+
+    def self.counter_warmup
+      !!@counter_warmup_enabled
+    end
+
     attr_reader :data
 
     def initialize(name, help)
@@ -15,10 +26,12 @@ module PrometheusExporter::Metric
 
     def reset!
       @data = {}
+      @counter_warmup = {}
     end
 
     def metric_text
-      @data.map do |labels, value|
+      @data.keys.map do |labels|
+        value = warmup_counter_value(labels)
         "#{prefix(@name)}#{labels_text(labels)} #{value}"
       end.join("\n")
     end
@@ -28,26 +41,43 @@ module PrometheusExporter::Metric
     end
 
     def remove(labels)
+      @counter_warmup.delete(labels)
       @data.delete(labels)
     end
 
     def observe(increment = 1, labels = {})
+      warmup_counter(labels)
       @data[labels] ||= 0
       @data[labels] += increment
     end
 
     def increment(labels = {}, value = 1)
+      warmup_counter(labels)
       @data[labels] ||= 0
       @data[labels] += value
     end
 
     def decrement(labels = {}, value = 1)
+      warmup_counter(labels)
       @data[labels] ||= 0
       @data[labels] -= value
     end
 
     def reset(labels = {}, value = 0)
+      warmup_counter(labels)
       @data[labels] = value
+    end
+
+    private
+
+    def warmup_counter(labels)
+      if Counter.counter_warmup && !@data.has_key?(labels)
+        @counter_warmup[labels] = 0
+      end
+    end
+
+    def warmup_counter_value(labels)
+      @counter_warmup.delete(labels) || @data[labels]
     end
   end
 end

--- a/lib/prometheus_exporter/server/runner.rb
+++ b/lib/prometheus_exporter/server/runner.rb
@@ -17,6 +17,7 @@ module PrometheusExporter::Server
       @auth = nil
       @realm = nil
       @histogram = nil
+      @counter = nil
 
       options.each do |k, v|
         send("#{k}=", v) if self.class.method_defined?("#{k}=")
@@ -26,6 +27,7 @@ module PrometheusExporter::Server
     def start
       PrometheusExporter::Metric::Base.default_prefix = prefix
       PrometheusExporter::Metric::Base.default_labels = label
+      PrometheusExporter::Metric::Counter.counter_warmup = counter_warmup
 
       if histogram
         PrometheusExporter::Metric::Base.default_aggregation = PrometheusExporter::Metric::Histogram
@@ -54,7 +56,7 @@ module PrometheusExporter::Server
     end
 
     attr_accessor :unicorn_listen_address, :unicorn_pid_file
-    attr_writer :prefix, :port, :bind, :collector_class, :type_collectors, :timeout, :verbose, :server_class, :label, :auth, :realm, :histogram
+    attr_writer :prefix, :port, :bind, :collector_class, :type_collectors, :timeout, :verbose, :server_class, :label, :auth, :realm, :histogram, :counter_warmup
 
     def auth
       @auth || nil
@@ -107,6 +109,10 @@ module PrometheusExporter::Server
 
     def histogram
       @histogram || false
+    end
+
+    def counter_warmup
+      @counter_warmup || false
     end
 
     private

--- a/lib/prometheus_exporter/server/runner.rb
+++ b/lib/prometheus_exporter/server/runner.rb
@@ -17,7 +17,7 @@ module PrometheusExporter::Server
       @auth = nil
       @realm = nil
       @histogram = nil
-      @counter = nil
+      @counter_warmup = nil
 
       options.each do |k, v|
         send("#{k}=", v) if self.class.method_defined?("#{k}=")

--- a/test/server/runner_test.rb
+++ b/test/server/runner_test.rb
@@ -72,7 +72,8 @@ class PrometheusRunnerTest < Minitest::Test
       label: { environment: 'integration' },
       auth: 'my_htpasswd_file',
       realm: 'test realm',
-      histogram: true
+      histogram: true,
+      counter_warmup: true
     )
 
     assert_equal(runner.prefix, 'new_')
@@ -85,6 +86,7 @@ class PrometheusRunnerTest < Minitest::Test
     assert_equal(runner.auth, 'my_htpasswd_file')
     assert_equal(runner.realm, 'test realm')
     assert_equal(runner.histogram, true)
+    assert_equal(runner.counter_warmup, true)
 
     reset_base_metric_label
   end

--- a/test/server/runner_test.rb
+++ b/test/server/runner_test.rb
@@ -3,6 +3,8 @@
 require_relative '../test_helper'
 require 'prometheus_exporter/server'
 
+require 'ostruct'
+
 class PrometheusRunnerTest < Minitest::Test
   class MockerWebServer < OpenStruct
     def start


### PR DESCRIPTION
Inspired by [smart-prometheus-client](https://github.com/goto-opensource/smart-prometheus-client?tab=readme-ov-file#counters-warm-up), add an option to return 0 on first scrape.

As mentioned on that page, it can help with with problem of [missing metrics](https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics)

