### PR TITLE
Fallback to detect controller and action as symbols

### DIFF
--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -63,8 +63,8 @@ class PrometheusExporter::Middleware
     params = env["action_dispatch.request.parameters"]
     action = controller = nil
     if params
-      action = params["action"]
-      controller = params["controller"]
+      action = params["action"] || params[:action]
+      controller = params["controller"] || params[:controller]
     elsif (cors = env["rack.cors"]) && cors.respond_to?(:preflight?) && cors.preflight?
       # if the Rack CORS Middleware identifies the request as a preflight request,
       # the stack doesn't get to the point where controllers/actions are defined


### PR DESCRIPTION
In our Rails 7.1.3.2 app, action_dispatch.request.parameters is a hash with symbols. This adds a fallback to detect the action and controller names if they are symbols.