### PR TITLE
Add exec_params to profiled pg methods

### DIFF
--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -23,7 +23,7 @@ class PrometheusExporter::Middleware
       end
       if defined? PG::Connection
         MethodProfiler.patch(PG::Connection, [
-          :exec, :async_exec, :exec_prepared, :send_query_prepared, :query
+          :exec, :async_exec, :exec_prepared, :exec_params, :send_query_prepared, :query
         ], :sql, instrument: config[:instrument])
       end
       if defined? Mysql2::Client


### PR DESCRIPTION
ActiveRecord uses `PG::Connection#exec_params` for queries that are not cached (via `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_no_cache / #execute_and_clear). As this method is not profiled, a substantial amount of queries, and hence DB time is missing from the prometheus instrumentation.

This PR adds the missing method to the list of profiled methods.