### PR TITLE
Install curl on the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG GEM_VERSION=
 
 FROM ruby:${RUBY_VERSION}-slim
 
+RUN apt update && apt install -y curl
+
 RUN gem install --no-doc --version=${GEM_VERSION} prometheus_exporter
 
 EXPOSE 9394


### PR DESCRIPTION
This PR adds the `curl` utility to the Prometheus Exporter Docker image (`ghcr.io/discourse/prometheus_exporter`).

**Changes Made:**
- Updated the Dockerfile to install `curl` during the image build process.
- This ensures that the curl command is available in the container, which is critical for performing health checks (e.g., `curl -sSf http://localhost:9394/ping`).
