### PR TITLE
Add puma_busy_threads gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ end
 | Gauge | `puma_booted_workers`       | Number of puma workers booted                               |
 | Gauge | `puma_old_workers`          | Number of old puma workers                                  |
 | Gauge | `puma_running_threads`      | Number of puma threads currently running                    |
+| Gauge | `puma_busy_threads`         | Number of puma threads currently busy                       |
 | Gauge | `puma_request_backlog`      | Number of requests waiting to be processed by a puma thread |
 | Gauge | `puma_thread_pool_capacity` | Number of puma threads available at current scale           |
 | Gauge | `puma_max_threads`          | Number of puma threads at available at max scale            |

--- a/lib/prometheus_exporter/instrumentation/puma.rb
+++ b/lib/prometheus_exporter/instrumentation/puma.rb
@@ -60,11 +60,13 @@ module PrometheusExporter::Instrumentation
       metric[:request_backlog] ||= 0
       metric[:running_threads] ||= 0
       metric[:thread_pool_capacity] ||= 0
+      metric[:busy_threads] ||= 0
       metric[:max_threads] ||= 0
 
       metric[:request_backlog] += status["backlog"]
       metric[:running_threads] += status["running"]
       metric[:thread_pool_capacity] += status["pool_capacity"]
+      metric[:busy_threads] += status["busy_threads"]
       metric[:max_threads] += status["max_threads"]
     end
   end

--- a/lib/prometheus_exporter/server/puma_collector.rb
+++ b/lib/prometheus_exporter/server/puma_collector.rb
@@ -8,6 +8,7 @@ module PrometheusExporter::Server
       booted_workers: "Number of puma workers booted.",
       old_workers: "Number of old puma workers.",
       running_threads: "Number of puma threads currently running.",
+      busy_threads: "Number of puma threads currently busy.",
       request_backlog: "Number of requests waiting to be processed by a puma thread.",
       thread_pool_capacity: "Number of puma threads available at current scale.",
       max_threads: "Number of puma threads at available at max scale.",

--- a/test/server/puma_collector_test.rb
+++ b/test/server/puma_collector_test.rb
@@ -23,6 +23,7 @@ class PrometheusPumaCollectorTest < Minitest::Test
       "old_workers" => 0,
       "request_backlog" => 0,
       "running_threads" => 4,
+      "busy_threads" => 6,
       "thread_pool_capacity" => 10,
       "max_threads" => 10,
     )
@@ -37,6 +38,7 @@ class PrometheusPumaCollectorTest < Minitest::Test
       "old_workers" => 0,
       "request_backlog" => 1,
       "running_threads" => 9,
+      "busy_threads" => 10,
       "thread_pool_capacity" => 10,
       "max_threads" => 10,
     )
@@ -52,6 +54,7 @@ class PrometheusPumaCollectorTest < Minitest::Test
       "old_workers" => 0,
       "request_backlog" => 2,
       "running_threads" => 8,
+      "busy_threads" => 10,
       "thread_pool_capacity" => 10,
       "max_threads" => 10,
     )
@@ -72,6 +75,7 @@ class PrometheusPumaCollectorTest < Minitest::Test
       "old_workers" => 0,
       "request_backlog" => 0,
       "running_threads" => 4,
+      "busy_threads" => 4,
       "thread_pool_capacity" => 10,
       "max_threads" => 10,
       "custom_labels" => {
@@ -89,6 +93,7 @@ class PrometheusPumaCollectorTest < Minitest::Test
       "old_workers" => 0,
       "request_backlog" => 1,
       "running_threads" => 9,
+      "busy_threads" => 10,
       "thread_pool_capacity" => 10,
       "max_threads" => 10,
       "custom_labels" => {
@@ -107,6 +112,7 @@ class PrometheusPumaCollectorTest < Minitest::Test
       "old_workers" => 0,
       "request_backlog" => 2,
       "running_threads" => 8,
+      "busy_threads" => 10,
       "thread_pool_capacity" => 10,
       "max_threads" => 10,
       "custom_labels" => {


### PR DESCRIPTION
In the latest puma version (6.6.0), they added a new stat called "busy_threads". More details in the MR https://github.com/puma/puma/pull/3517

In this MR, I'm adding it to this exporter, so we can have it available in prometheus.

Note: this stat will be available in 6.6.0, and I didn't make it optional. If anyone is using an older version of puma, this metric would report 0 at all times. Let me know if this trade-off is okay to you.