### PR TITLE
Add Ruby 3.4 + ActiveRecord 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3"]
-        activerecord: [61, 70, 71]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        activerecord: [61, 70, 71, 80]
+        # Exclude Ruby 3.1 with ActiveRecord 8 but allow others
+        exclude:
+          - ruby: "3.1"
+            activerecord: 80
+        include:
+          - ruby: "3.2"
+            activerecord: 80
+          - ruby: "3.3"
+            activerecord: 80
+          - ruby: "3.4"
+            activerecord: 80
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It will probably crash for 3.4 and older ActiveRecord version (?). We will see.