### PR TITLE
Adds handling for malformed metrics

### DIFF
--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
+require "logger"
+
 module PrometheusExporter::Server
   class Collector < CollectorBase
-    def initialize(json_serializer: nil)
+    attr_reader :logger
+
+    def initialize(json_serializer: nil, logger: Logger.new(STDERR))
+      @logger = logger
       @process_metrics = []
       @metrics = {}
       @mutex = Mutex.new
@@ -77,7 +82,7 @@ module PrometheusExporter::Server
       opts = symbolize_keys(obj["opts"] || {})
 
       if !name
-        STDERR.puts "failed to register metric due to empty name #{obj}"
+        logger.warn "failed to register metric due to empty name #{obj}"
         return
       end
 
@@ -96,7 +101,7 @@ module PrometheusExporter::Server
       if metric
         @metrics[name] = metric
       else
-        STDERR.puts "failed to register metric #{obj}"
+        logger.warn "failed to register metric #{obj}"
       end
     end
 

--- a/lib/prometheus_exporter/server/collector.rb
+++ b/lib/prometheus_exporter/server/collector.rb
@@ -40,6 +40,8 @@ module PrometheusExporter::Server
           metric = @metrics[obj["name"]]
           metric = register_metric_unsafe(obj) if !metric
 
+          next unless metric
+
           keys = obj["keys"] || {}
           keys = obj["custom_labels"].merge(keys) if obj["custom_labels"]
 
@@ -73,6 +75,11 @@ module PrometheusExporter::Server
       name = obj["name"]
       help = obj["help"]
       opts = symbolize_keys(obj["opts"] || {})
+
+      if !name
+        STDERR.puts "failed to register metric due to empty name #{obj}"
+        return
+      end
 
       metric =
         case obj["type"]

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -12,7 +12,6 @@ module PrometheusExporter::Server
     def initialize(opts)
       @port = opts[:port] || PrometheusExporter::DEFAULT_PORT
       @bind = opts[:bind] || PrometheusExporter::DEFAULT_BIND_ADDRESS
-      @collector = opts[:collector] || Collector.new
       @timeout = opts[:timeout] || PrometheusExporter::DEFAULT_TIMEOUT
       @verbose = opts[:verbose] || false
       @auth = opts[:auth]
@@ -60,6 +59,8 @@ module PrometheusExporter::Server
         @logger.info "Listening on both 0.0.0.0/:: network interfaces"
         @bind = nil
       end
+
+      @collector = opts[:collector] || Collector.new(logger: @logger)
 
       @server =
         WEBrick::HTTPServer.new(

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -100,6 +100,22 @@ class PrometheusCollectorTest < Minitest::Test
     assert_equal(text, collector.prometheus_metrics_text)
   end
 
+  def test_malformed_metric_without_name_or_action
+    collector = PrometheusExporter::Server::Collector.new
+
+    json = {
+      type: :gauge,
+      keys: {
+        key1: "test1",
+      },
+      value: 1,
+    }.to_json
+
+    collector.process(json)
+
+    assert_equal("", collector.prometheus_metrics_text)
+  end
+
   def test_it_can_increment_gauge_when_specified
     name = "test_name"
     help = "test_help"


### PR DESCRIPTION
In the Ruby GraphQL gem we have observed some interesting behavior where collectors appear not to be registered, which causes the code from that gem to error:

```ruby
@trace.prometheus_client.send_json(
  # [!!] No name here
  type: @trace.prometheus_collector_type,
  duration: duration,
  platform_key: event_name,
  key: keyword
)
```

Source: https://github.com/rmosolgo/graphql-ruby/blob/ddf2550a204be69ba681739b529324a074d72c91/lib/graphql/tracing/prometheus_trace.rb#L68

On one hand this appears to be a malformed request body as-is, and the tests do not appear to test the integration in validating this behavior.

Given that, that brings up a potential edge case which may warrant some discussion: What should PrometheusExporter do in a case where it gets a malformed metric that does not have a name? Should it give an error? Right now what it returns is this:

```ruby
#nomethoderror: undefined method `observe' for nil:NilClass - /opt/ruby3.0/lib/ruby/gems/3.0.0/gems/prometheus_exporter-0.8.1/lib/prometheus_exporter/server/collector.rb:55:in `block in process_hash'
```

...which does not give clear traceability into the cause and potential resolutions.

The opinion of this PR, at least, is to allow it to gracefully fail when a metric cannot be registered but I am not convinced that this is the correct behavior in this scenario and would defer to the folks working on the project as to what makes the most sense here.

My suspicion with the upstream issue is that it's some form of race condition in loading collectors.

Documented some things on the GraphQL gem:

https://github.com/rmosolgo/graphql-ruby/issues/5323

Still suspecting some type of loading or race condition in here.