### PR TITLE
DEV: Move linting to a seperate workflow to fix the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,6 @@ jobs:
           bundler: latest
           bundler-cache: true
 
-      - name: Rubocop
-        run: bundle exec rubocop
-
-      - name: Syntax tree
-        run: bundle exec stree check Gemfile $(git ls-files '*.rb') $(git ls-files '*.rake') $(git ls-files '*.thor')
-
       - name: Run tests
         run: bundle exec rake
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,28 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4
+          bundler: latest
+          bundler-cache: true
+
+      - name: Rubocop
+        run: bundle exec rubocop
+
+      - name: Syntax tree
+        run: bundle exec stree check Gemfile $(git ls-files '*.rb') $(git ls-files '*.rake') $(git ls-files '*.thor')

--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-stub-const", "~> 0.6"
   spec.add_development_dependency "rubocop-discourse", ">= 3"
   spec.add_development_dependency "appraisal", "~> 2.3"
-  spec.add_development_dependency "activerecord", "~> 6.0.0"
+  spec.add_development_dependency "activerecord", "~> 7.1"
   spec.add_development_dependency "redis", "> 5"
   spec.add_development_dependency "m"
   spec.add_development_dependency "syntax_tree"


### PR DESCRIPTION
We don't need to be running rubocop and stree multiple times