### PR TITLE
Fix syntax tree errors on main branch

### DIFF
--- a/lib/prometheus_exporter/server/puma_collector.rb
+++ b/lib/prometheus_exporter/server/puma_collector.rb
@@ -13,8 +13,11 @@ module PrometheusExporter::Server
       max_threads: "Number of puma threads at available at max scale.",
     }
 
-    if defined?(::Puma::Const) && Gem::Version.new(::Puma::Const::VERSION) >= Gem::Version.new('6.6.0')
-      PUMA_GAUGES[:busy_threads] = "Wholistic stat reflecting the overall current state of work to be done and the capacity to do it"
+    if defined?(::Puma::Const) &&
+         Gem::Version.new(::Puma::Const::VERSION) >= Gem::Version.new("6.6.0")
+      PUMA_GAUGES[
+        :busy_threads
+      ] = "Wholistic stat reflecting the overall current state of work to be done and the capacity to do it"
     end
 
     def initialize

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,7 +71,7 @@ unless defined?(::Puma)
     end
 
     def self.stats
-      '{}'
+      "{}"
     end
   end
 end


### PR DESCRIPTION
Hello

I noticed that my PR #333 merge introduce `stree` failures. This PR fix that.

Now
```
» bundle exec stree check **/*.rb 
All files matched expected format.
```