### PR TITLE
fix: preserve full controller path 

### DIFF
--- a/lib/prometheus_exporter/middleware.rb
+++ b/lib/prometheus_exporter/middleware.rb
@@ -78,7 +78,7 @@ class PrometheusExporter::Middleware
     action = controller = nil
     if controller_instance
       action = controller_instance.action_name
-      controller = controller_instance.controller_name
+      controller = controller_instance.controller_path
     elsif (cors = env["rack.cors"]) && cors.respond_to?(:preflight?) && cors.preflight?
       # if the Rack CORS Middleware identifies the request as a preflight request,
       # the stack doesn't get to the point where controllers/actions are defined


### PR DESCRIPTION
### Background

A recent change in [this commit](https://github.com/discourse/prometheus_exporter/commit/2f1e7e9a89deeb107575bba69b1c3bd6c98c9d3f) altered how the controller name is recorded.

Previously, metrics used `params["controller"]`, which returns the full namespaced path:

```ruby
controller = params["controller"]
# => "authentication/sessions"
```

After the commit, we switched to using `controller_instance.controller_name`, which only returns the base controller name, stripping namespaces:

```ruby
controller = controller_instance.controller_name
# => "sessions"
```

### Problem

This change breaks existing queries on our side that rely on the full path. For example:

```promql
http_requests_total{controller=~"authentication/.*"}
```

no longer matches because `controller_name` only provides `"sessions"` instead of `"authentication/sessions"`.

### Solution

Use `controller_instance.controller_path`, which preserves the previous behavior:

```ruby
controller = controller_instance.controller_path
# => "authentication/sessions"
```

This restores compatibility with existing queries.