### PR TITLE
[DGR-3799] Fix `custom_labels` merge in Sidekiq process and stats collectors

### DIFF
--- a/lib/prometheus_exporter/server/sidekiq_process_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_process_collector.rb
@@ -41,7 +41,10 @@ module PrometheusExporter::Server
     end
 
     def collect(object)
-      @sidekiq_metrics << object["process"]
+      process = object["process"]
+      process["labels"] ||= {}
+      process["labels"].merge!(object["custom_labels"]) if object["custom_labels"]
+      @sidekiq_metrics << process
     end
   end
 end

--- a/lib/prometheus_exporter/server/sidekiq_stats_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_stats_collector.rb
@@ -30,11 +30,12 @@ module PrometheusExporter::Server
       SIDEKIQ_STATS_GAUGES.each_key { |name| gauges[name]&.reset! }
 
       sidekiq_metrics.map do |metric|
+        labels = metric.fetch("labels", {})
         SIDEKIQ_STATS_GAUGES.map do |name, help|
           if (value = metric["stats"][name])
             gauge =
               gauges[name] ||= PrometheusExporter::Metric::Gauge.new("sidekiq_stats_#{name}", help)
-            gauge.observe(value)
+            gauge.observe(value, labels)
           end
         end
       end
@@ -43,6 +44,7 @@ module PrometheusExporter::Server
     end
 
     def collect(object)
+      object["labels"] = object.fetch("custom_labels", {})
       @sidekiq_metrics << object
     end
   end

--- a/test/server/collector_test.rb
+++ b/test/server/collector_test.rb
@@ -751,13 +751,13 @@ class PrometheusCollectorTest < Minitest::Test
     result = collector.prometheus_metrics_text
     assert(
       result.include?(
-        %Q[sidekiq_process_busy{labels="lab_1,lab_2",queues="queue_1,queue_2",quiet="false",tag="default",hostname="#{PrometheusExporter.hostname}",identity="hostname:0"} 1],
+        %Q[sidekiq_process_busy{labels="lab_1,lab_2",queues="queue_1,queue_2",quiet="false",tag="default",hostname="#{PrometheusExporter.hostname}",identity="hostname:0",service="service1"} 1],
       ),
       "has number of busy",
     )
     assert(
       result.include?(
-        %Q[sidekiq_process_concurrency{labels="lab_1,lab_2",queues="queue_1,queue_2",quiet="false",tag="default",hostname="#{PrometheusExporter.hostname}",identity="hostname:0"} 2],
+        %Q[sidekiq_process_concurrency{labels="lab_1,lab_2",queues="queue_1,queue_2",quiet="false",tag="default",hostname="#{PrometheusExporter.hostname}",identity="hostname:0",service="service1"} 2],
       ),
       "has number of concurrency",
     )
@@ -790,14 +790,14 @@ class PrometheusCollectorTest < Minitest::Test
     end
 
     result = collector.prometheus_metrics_text
-    assert_includes(result, "sidekiq_stats_dead_size 1")
-    assert_includes(result, "sidekiq_stats_enqueued 2")
-    assert_includes(result, "sidekiq_stats_failed 3")
-    assert_includes(result, "sidekiq_stats_processed 4")
-    assert_includes(result, "sidekiq_stats_processes_size 5")
-    assert_includes(result, "sidekiq_stats_retry_size 6")
-    assert_includes(result, "sidekiq_stats_scheduled_size 7")
-    assert_includes(result, "sidekiq_stats_workers_size 8")
+    assert_includes(result, 'sidekiq_stats_dead_size{service="service1"} 1')
+    assert_includes(result, 'sidekiq_stats_enqueued{service="service1"} 2')
+    assert_includes(result, 'sidekiq_stats_failed{service="service1"} 3')
+    assert_includes(result, 'sidekiq_stats_processed{service="service1"} 4')
+    assert_includes(result, 'sidekiq_stats_processes_size{service="service1"} 5')
+    assert_includes(result, 'sidekiq_stats_retry_size{service="service1"} 6')
+    assert_includes(result, 'sidekiq_stats_scheduled_size{service="service1"} 7')
+    assert_includes(result, 'sidekiq_stats_workers_size{service="service1"} 8')
     mock_sidekiq_stats.verify
     mock_sidekiq_stats_new.verify
   end

--- a/test/server/sidekiq_process_collector_test.rb
+++ b/test/server/sidekiq_process_collector_test.rb
@@ -35,6 +35,30 @@ class PrometheusSidekiqProcessCollectorTest < Minitest::Test
     assert_equal expected, metrics.map(&:metric_text)
   end
 
+  def test_collecting_metrics_with_client_default_labels
+    collector.collect(
+      "process" => {
+        "busy" => 1,
+        "concurrency" => 2,
+        "labels" => {
+          "queues" => "default,reliable",
+          "quiet" => "false",
+        },
+      },
+      "custom_labels" => {
+        "service_component" => "sidekiq",
+        "hostname" => "worker-1",
+      },
+    )
+
+    metrics = collector.metrics
+    expected = [
+      'sidekiq_process_busy{queues="default,reliable",quiet="false",service_component="sidekiq",hostname="worker-1"} 1',
+      'sidekiq_process_concurrency{queues="default,reliable",quiet="false",service_component="sidekiq",hostname="worker-1"} 2',
+    ]
+    assert_equal expected, metrics.map(&:metric_text)
+  end
+
   def test_only_fresh_metrics_are_collected
     stub_monotonic_clock(1.0) do
       collector.collect(

--- a/test/server/sidekiq_stats_collector_test.rb
+++ b/test/server/sidekiq_stats_collector_test.rb
@@ -39,6 +39,38 @@ class PrometheusSidekiqStatsCollectorTest < Minitest::Test
     assert_equal expected, metrics.map(&:metric_text)
   end
 
+  def test_collecting_metrics_with_client_default_labels
+    collector.collect(
+      "stats" => {
+        "dead_size" => 1,
+        "enqueued" => 2,
+        "failed" => 3,
+        "processed" => 4,
+        "processes_size" => 5,
+        "retry_size" => 6,
+        "scheduled_size" => 7,
+        "workers_size" => 8,
+      },
+      "custom_labels" => {
+        "service_component" => "sidekiq",
+        "hostname" => "worker-1",
+      },
+    )
+
+    metrics = collector.metrics
+    expected = [
+      'sidekiq_stats_dead_size{service_component="sidekiq",hostname="worker-1"} 1',
+      'sidekiq_stats_enqueued{service_component="sidekiq",hostname="worker-1"} 2',
+      'sidekiq_stats_failed{service_component="sidekiq",hostname="worker-1"} 3',
+      'sidekiq_stats_processed{service_component="sidekiq",hostname="worker-1"} 4',
+      'sidekiq_stats_processes_size{service_component="sidekiq",hostname="worker-1"} 5',
+      'sidekiq_stats_retry_size{service_component="sidekiq",hostname="worker-1"} 6',
+      'sidekiq_stats_scheduled_size{service_component="sidekiq",hostname="worker-1"} 7',
+      'sidekiq_stats_workers_size{service_component="sidekiq",hostname="worker-1"} 8',
+    ]
+    assert_equal expected, metrics.map(&:metric_text)
+  end
+
   def test_only_fresh_metrics_are_collected
     stub_monotonic_clock(1.0) do
       collector.collect(


### PR DESCRIPTION
## Jira Issue
[DGR-3799](https://accredible.atlassian.net/browse/DGR-3799)

## Summary
- Fix `custom_labels` (including `service_component`) being discarded by the Sidekiq process and stats collectors, causing these metrics to fall back to `service_name=acms` instead of `acms-sidekiq` after Alloy relabeling
- Align both collectors with the queue collector's existing pattern of merging `custom_labels` into the labels hash

## Changes
1. **Process collector**: `lib/prometheus_exporter/server/sidekiq_process_collector.rb`
   - Merge `custom_labels` into `process["labels"]` in `collect()` (same pattern as queue collector)

2. **Stats collector**: `lib/prometheus_exporter/server/sidekiq_stats_collector.rb`
   - Store `custom_labels` as `object["labels"]` in `collect()`
   - Pass labels to `gauge.observe(value, labels)` in `metrics()` (was previously called with no labels)

3. **Test coverage**: `test/server/sidekiq_process_collector_test.rb`, `test/server/sidekiq_stats_collector_test.rb`
   - Added `test_collecting_metrics_with_client_default_labels` to both collectors verifying `service_component` and `hostname` labels appear in metric output

4. **Integration test updates**: `test/server/collector_test.rb`
   - Updated process and stats integration test assertions to expect `custom_labels` in metric output (since `PipedClient` sends `custom_labels`)