### PR TITLE
DEV: replace WEBrick with a minimal vendored HTTP server

### DIFF
--- a/lib/prometheus_exporter/server/http/VENDORED_WEBRICK_LICENSE.txt
+++ b/lib/prometheus_exporter/server/http/VENDORED_WEBRICK_LICENSE.txt
@@ -1,0 +1,57 @@
+WEBrick vendored source notice
+==============================
+
+The focused HTTP implementation in this directory contains source-derived logic
+from WEBrick master commit:
+
+    25b0e9206bf5991c6274893d53c428d23b3f2292
+    "Only allow specific trailers" (2026-07-18)
+
+Upstream source: https://github.com/ruby/webrick
+
+Only the request parsing, HTTP response framing, connection/listener lifecycle,
+TLS wrapping, and Apache crypt htpasswd Basic authentication behavior needed by
+prometheus_exporter were retained. The code was pruned and re-namespaced under
+PrometheusExporter::Server::HTTP; it does not define the WEBrick constant.
+
+Upstream license (BSD-2-Clause)
+-------------------------------
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+Source-file attribution retained from the derived upstream files
+------------------------------------------------------------------
+
+HTTPRequest, GenericServer, HTTPServer, HTTPResponse, and Utils-derived logic:
+
+    Author: IPR -- Internet Programming with Ruby -- writers
+    Copyright (c) 2000, 2001 TAKAHASHI Masayoshi, GOTOU Yuuzou
+    Copyright (c) 2002 Internet Programming with Ruby writers.
+    All rights reserved.
+
+HTTPAuth::BasicAuth and HTTPAuth::Htpasswd-derived logic:
+
+    Author: IPR -- Internet Programming with Ruby -- writers
+    Copyright (c) 2003 Internet Programming with Ruby writers.
+    All rights reserved.

--- a/lib/prometheus_exporter/server/http/basic_authenticator.rb
+++ b/lib/prometheus_exporter/server/http/basic_authenticator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+#
+# This file contains logic derived from WEBrick HTTPAuth::BasicAuth and Htpasswd.
+# Copyright (c) 2003 Internet Programming with Ruby writers. All rights reserved.
+# Vendored from WEBrick commit 25b0e9206bf5991c6274893d53c428d23b3f2292.
+# See VENDORED_WEBRICK_LICENSE.txt for the BSD-2-Clause terms.
+
+module PrometheusExporter
+  module Server
+    module HTTP
+      class BasicAuthenticator
+        CRYPT_ENTRY = /\A([^:]+):([a-zA-Z0-9.\/]{13})\z/
+
+        attr_reader :realm
+
+        def initialize(path:, realm:, logger:)
+          realm = realm.to_s
+          raise ArgumentError, "realm contains control characters" if /[[:cntrl:]]/.match?(realm)
+
+          @path = path
+          @realm = realm
+          @logger = logger
+          @mtime = Time.at(0)
+          @passwords = {}
+          File.open(@path, "a").close unless File.exist?(@path)
+          reload
+        end
+
+        def authenticate(authorization)
+          match = /\ABasic\s+(.+)\z/i.match(authorization.to_s)
+          return false unless match
+
+          credentials = match[1].unpack1("m").split(":", 2)
+          user = credentials[0]
+          password = credentials[1] || ""
+          return false if user.nil? || user.empty?
+
+          reload
+          encrypted = @passwords[user]
+          encrypted && password.crypt(encrypted) == encrypted
+        rescue ArgumentError
+          false
+        end
+
+        def challenge
+          escaped_realm = @realm.gsub(/["\\]/) { |character| "\\#{character}" }
+          %(Basic realm="#{escaped_realm}")
+        end
+
+        private
+
+        def reload
+          mtime = File.mtime(@path)
+          return if mtime <= @mtime
+
+          passwords = {}
+          File.foreach(@path, chomp: true) do |line|
+            match = CRYPT_ENTRY.match(line)
+            if !match
+              if /:\$|:{SHA}/.match?(line)
+                raise NotImplementedError, "MD5 and SHA1 .htpasswd entries are not supported"
+              end
+              raise StandardError, "bad .htpasswd file"
+            end
+            passwords[match[1]] = match[2]
+          end
+          @passwords = passwords
+          @mtime = mtime
+        rescue Errno::ENOENT => e
+          @logger.error("Unable to read htpasswd file #{@path}: #{e.message}")
+          raise
+        end
+      end
+    end
+  end
+end

--- a/lib/prometheus_exporter/server/http/request.rb
+++ b/lib/prometheus_exporter/server/http/request.rb
@@ -1,0 +1,394 @@
+# frozen_string_literal: true
+#
+# This file contains logic derived from WEBrick request parsing.
+# Copyright (c) 2000, 2001 TAKAHASHI Masayoshi, GOTOU Yuuzou.
+# Copyright (c) 2002 Internet Programming with Ruby writers. All rights reserved.
+# Vendored from WEBrick commit 25b0e9206bf5991c6274893d53c428d23b3f2292.
+# See VENDORED_WEBRICK_LICENSE.txt for the BSD-2-Clause terms.
+
+require "socket"
+require "timeout"
+
+module PrometheusExporter
+  module Server
+    module HTTP
+      STATUS_MESSAGES = {
+        100 => "Continue",
+        101 => "Switching Protocols",
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        204 => "No Content",
+        206 => "Partial Content",
+        300 => "Multiple Choices",
+        301 => "Moved Permanently",
+        302 => "Found",
+        303 => "See Other",
+        304 => "Not Modified",
+        307 => "Temporary Redirect",
+        308 => "Permanent Redirect",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        408 => "Request Timeout",
+        409 => "Conflict",
+        410 => "Gone",
+        411 => "Length Required",
+        412 => "Precondition Failed",
+        413 => "Request Entity Too Large",
+        414 => "Request-URI Too Large",
+        415 => "Unsupported Media Type",
+        416 => "Range Not Satisfiable",
+        417 => "Expectation Failed",
+        422 => "Unprocessable Entity",
+        426 => "Upgrade Required",
+        428 => "Precondition Required",
+        429 => "Too Many Requests",
+        431 => "Request Header Fields Too Large",
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        505 => "HTTP Version Not Supported",
+      }.freeze
+      UNKNOWN_STATUS_MESSAGE = "Unknown Status"
+
+      def self.status_message(status)
+        STATUS_MESSAGES.fetch(status, UNKNOWN_STATUS_MESSAGE)
+      end
+
+      class Error < StandardError
+        attr_reader :status
+
+        def initialize(status, message = nil)
+          @status = status
+          super(message || HTTP.status_message(status))
+        end
+      end
+
+      class EndOfStream < StandardError
+      end
+
+      class Request
+        MAX_REQUEST_LINE = 2083
+        MAX_HEADER_LENGTH = 112 * 1024
+        MAX_LINE_LENGTH = 4096
+        INPUT_BUFFER_SIZE = 65_536
+        BODY_METHODS = %w[POST PUT].freeze
+        METHOD_TOKEN = /\A[!#$%&'*+\-.^_`|~0-9A-Za-z]+\z/
+        REG_NAME =
+          /\A(?=.{1,253}\z)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(?:\.(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*\z/
+
+        attr_reader :headers, :http_version, :method, :path, :request_line, :target
+
+        def initialize(socket, read_timeout:)
+          @socket = socket
+          @read_timeout = read_timeout
+          @headers = nil
+          @request_bytes = 0
+          @body_complete = false
+        end
+
+        def parse
+          read_request_line
+          read_headers
+          validate_host
+          validate_framing
+          self
+        end
+
+        def [](name)
+          values = @headers[name.downcase]
+          values.empty? ? nil : values.join(", ")
+        end
+
+        def keep_alive?
+          connection = self["connection"].to_s.downcase.split(",").map!(&:strip)
+          return false if connection.include?("close")
+
+          @http_version == "1.1" || connection.include?("keep-alive")
+        end
+
+        def each_body_chunk(&block)
+          return if @body_complete
+
+          if self["transfer-encoding"]
+            read_chunked(&block)
+          elsif self["content-length"]
+            read_fixed_length(Integer(self["content-length"], 10), &block)
+          elsif BODY_METHODS.include?(@method)
+            raise Error.new(411)
+          else
+            @body_complete = true
+          end
+        end
+
+        def finish
+          each_body_chunk { |_chunk| }
+        end
+
+        private
+
+        def read_request_line
+          @request_line = read_line(MAX_REQUEST_LINE)
+          raise EndOfStream unless @request_line
+
+          @request_bytes = @request_line.bytesize
+          if @request_bytes >= MAX_REQUEST_LINE && !@request_line.end_with?("\n")
+            raise Error.new(414)
+          end
+
+          match = %r{\A(\S+) (\S++) HTTP/(\d+\.\d+)\r\n\z}m.match(@request_line)
+          raise Error.new(400, "bad Request-Line") unless match
+
+          @method, @target, @http_version = match.captures
+          raise Error.new(400, "invalid method token") unless METHOD_TOKEN.match?(@method)
+          raise Error.new(505) if %w[1.0 1.1].none? { |version| version == @http_version }
+
+          @path = extract_path(@target)
+        end
+
+        def extract_path(target)
+          if target == "*"
+            raise Error.new(400, "bad request target") unless @method == "OPTIONS"
+
+            return target
+          end
+
+          if @method == "CONNECT"
+            unless valid_authority?(target, require_port: true)
+              raise Error.new(400, "bad CONNECT target")
+            end
+
+            return target
+          end
+
+          raw_path =
+            if target.start_with?("/")
+              target.split("?", 2).first
+            elsif (match = %r{\Ahttps?://([^/]+)(/[^#]*)?\z}i.match(target))
+              raise Error.new(400, "bad request target") unless valid_authority?(match[1])
+
+              (match[2] || "/").split("?", 2).first
+            else
+              raise Error.new(400, "bad request target")
+            end
+
+          raise Error.new(400, "bad request target") if /%(?![0-9a-fA-F]{2})/.match?(raw_path)
+
+          raw_path.gsub(/%([0-9a-fA-F]{2})/) { $1.to_i(16).chr }
+        end
+
+        def read_headers(trailers: false)
+          lines = []
+          complete = false
+
+          while (line = read_line)
+            if line == "\r\n"
+              complete = true
+              break
+            end
+
+            @request_bytes += line.bytesize
+            raise Error.new(413, "headers too large") if @request_bytes > MAX_HEADER_LENGTH
+            raise Error.new(400, "null byte in header") if line.include?("\0")
+
+            lines << line
+          end
+
+          raise Error.new(400, "incomplete headers") unless complete
+
+          parsed = parse_headers(lines)
+          @headers = parsed unless trailers
+          nil
+        end
+
+        def parse_headers(lines)
+          header = Hash.new([].freeze)
+          field = nil
+
+          lines.each do |line|
+            if (match = /\A([A-Za-z0-9!#$%&'*+\-.^_`|~]+):([^\r\n\0]*?)\r\n\z/m.match(line))
+              field = match[1].downcase
+              header[field] = [] unless header.key?(field)
+              header[field] << match[2]
+            elsif (match = /\A[ \t]+([^\r\n\0]*?)\r\n\z/m.match(line))
+              raise Error.new(400, "bad header") unless field
+
+              header[field][-1] << " " << match[1]
+            else
+              raise Error.new(400, "bad header")
+            end
+          end
+
+          header.each_value do |values|
+            values.each do |value|
+              value.sub!(/\A[ \t]+/, "")
+              value.sub!(/[ \t]+\z/, "")
+            end
+          end
+          header
+        end
+
+        def validate_host
+          hosts = @headers["host"]
+          if @http_version == "1.1" && hosts.empty?
+            raise Error.new(400, "missing Host request header")
+          end
+          return if hosts.empty?
+
+          if hosts.length != 1 || !valid_authority?(hosts.first)
+            raise Error.new(400, "invalid Host request header")
+          end
+        end
+
+        def valid_authority?(authority, require_port: false)
+          host = nil
+          port = nil
+
+          if authority.start_with?("[")
+            match = /\A\[([^\]]+)\](?::(\d+))?\z/.match(authority)
+            return false unless match
+
+            return false unless valid_ipv6_address?(match[1])
+
+            host = match[1]
+            port = match[2]
+          else
+            if authority.count(":") > 1
+              return false if require_port
+
+              return valid_ipv6_address?(authority)
+            end
+
+            host, separator, port = authority.rpartition(":")
+            if separator.empty?
+              host = authority
+              port = nil
+            end
+            return false unless REG_NAME.match?(host)
+          end
+
+          return false if host.empty? || (require_port && port.nil?)
+          return true if port.nil?
+
+          /\A\d+\z/.match?(port) && port.to_i <= 65_535
+        end
+
+        def valid_ipv6_address?(address)
+          flags = Socket.const_defined?(:AI_NUMERICHOST) ? Socket::AI_NUMERICHOST : 0
+          Addrinfo.getaddrinfo(address, nil, Socket::AF_INET6, Socket::SOCK_STREAM, 0, flags)
+          true
+        rescue SocketError
+          false
+        end
+
+        def validate_framing
+          content_lengths = @headers["content-length"]
+          unless content_lengths.empty?
+            if content_lengths.length > 1
+              raise Error.new(400, "multiple content-length request headers")
+            end
+            unless /\A\d+\z/.match?(content_lengths.first)
+              raise Error.new(400, "invalid content-length request header")
+            end
+          end
+
+          transfer_encoding = self["transfer-encoding"]
+          return unless transfer_encoding
+
+          if self["content-length"]
+            raise Error.new(
+                    400,
+                    "request with both transfer-encoding and content-length, possible request smuggling",
+                  )
+          end
+          unless /\Achunked\z/i.match?(transfer_encoding)
+            raise Error.new(501, "unsupported transfer-encoding")
+          end
+        end
+
+        def read_fixed_length(remaining)
+          while remaining > 0
+            size = [remaining, INPUT_BUFFER_SIZE].min
+            data = read_data(size)
+            raise Error.new(400, "invalid body size") unless data&.bytesize == size
+
+            remaining -= data.bytesize
+            yield data
+          end
+          @body_complete = true
+        end
+
+        def read_chunked
+          chunk_size = read_chunk_size
+          while chunk_size > 0
+            remaining = chunk_size
+            while remaining > 0
+              size = [remaining, INPUT_BUFFER_SIZE].min
+              data = read_data(size)
+              raise Error.new(400, "bad chunk data size") unless data&.bytesize == size
+
+              yield data
+              remaining -= size
+            end
+
+            raise Error.new(400, "extra data after chunk") unless read_line == "\r\n"
+
+            chunk_size = read_chunk_size
+          end
+
+          # WEBrick master selectively imports requested, non-sensitive trailers.
+          # This focused server does not use trailers, so it validates their syntax
+          # and framing but safely discards every trailer field.
+          read_headers(trailers: true)
+          @body_complete = true
+        end
+
+        def read_chunk_size
+          line = read_line
+          raise Error.new(400, "bad chunk") unless line
+
+          match = /\A([0-9a-fA-F]+)(?:;(\S+(?:=\S+)?))?\r\n\z/.match(line)
+          raise Error.new(400, "bad chunk") unless match
+
+          match[1].to_i(16)
+        end
+
+        def read_line(limit = MAX_LINE_LENGTH)
+          timed_read { @socket.gets("\n", limit) }
+        end
+
+        def read_data(size)
+          timed_read { @socket.read(size) }
+        end
+
+        def timed_read
+          Timeout.timeout(@read_timeout) { yield }
+        rescue Timeout::Error
+          raise Error.new(408)
+        rescue EOFError, Errno::ECONNRESET, Errno::ECONNABORTED, IOError
+          nil
+        end
+      end
+
+      class Response
+        attr_accessor :body, :status
+        attr_reader :headers
+
+        def initialize(status: 200, body: "")
+          @status = status
+          @body = body
+          @headers = {}
+        end
+
+        def []=(name, value)
+          @headers[name] = value
+        end
+      end
+    end
+  end
+end

--- a/lib/prometheus_exporter/server/http/server.rb
+++ b/lib/prometheus_exporter/server/http/server.rb
@@ -1,0 +1,512 @@
+# frozen_string_literal: true
+#
+# This file contains logic derived from WEBrick GenericServer, HTTPServer,
+# HTTPResponse, and Utils listener handling.
+# Copyright (c) 2000, 2001 TAKAHASHI Masayoshi, GOTOU Yuuzou.
+# Copyright (c) 2002 Internet Programming with Ruby writers. All rights reserved.
+# Vendored from WEBrick commit 25b0e9206bf5991c6274893d53c428d23b3f2292.
+# See VENDORED_WEBRICK_LICENSE.txt for the BSD-2-Clause terms.
+
+require "socket"
+require_relative "request"
+
+module PrometheusExporter
+  module Server
+    module HTTP
+      class Server
+        DEFAULT_MAX_CLIENTS = 100
+        DEFAULT_REQUEST_TIMEOUT = 30
+        DEFAULT_SHUTDOWN_TIMEOUT = 5
+        DEFAULT_WRITE_TIMEOUT = 30
+        HEADER_NAME = /\A[!#$%&'*+\-.^_`|~0-9A-Za-z]+\z/
+        INVALID_HEADER_VALUE = /[\x00-\x08\x0A-\x1F\x7F]/n
+
+        def initialize(
+          bind:,
+          port:,
+          logger:,
+          max_clients: DEFAULT_MAX_CLIENTS,
+          request_timeout: DEFAULT_REQUEST_TIMEOUT,
+          shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+          write_timeout: DEFAULT_WRITE_TIMEOUT,
+          ssl_context: nil,
+          &handler
+        )
+          raise ArgumentError, "handler is required" unless handler
+          raise ArgumentError, "max_clients must be positive" unless max_clients.to_i.positive?
+
+          @request_timeout = positive_timeout(request_timeout, "request_timeout")
+          @shutdown_timeout = positive_timeout(shutdown_timeout, "shutdown_timeout")
+          @write_timeout = positive_timeout(write_timeout, "write_timeout")
+          @bind = bind
+          @port = Integer(port)
+          @logger = logger
+          @handler = handler
+          @ssl_context = ssl_context
+          @tokens = Thread::SizedQueue.new(max_clients.to_i)
+          max_clients.to_i.times { @tokens.push(nil) }
+
+          @mutex = Mutex.new
+          @state_changed = ConditionVariable.new
+          @state = :new
+          @listeners = []
+          @client_sockets = {}
+          @client_threads = []
+          @accept_thread = nil
+          @shutdown_pipe = nil
+        end
+
+        def listeners
+          @mutex.synchronize { @listeners.dup }
+        end
+
+        def start
+          @mutex.synchronize do
+            raise "server cannot be started from #{@state} state" unless @state == :new
+
+            @state = :starting
+            begin
+              @shutdown_pipe = IO.pipe
+              @listeners = create_listeners(@bind, @port)
+              @accept_thread = Thread.new { accept_main }
+            rescue Exception
+              close_resources_locked
+              @state = :stopped
+              @state_changed.broadcast
+              raise
+            end
+
+            @state_changed.wait(@mutex) while @state == :starting
+            raise "server was shut down during startup" unless @state == :running
+
+            @accept_thread
+          end
+        end
+
+        def shutdown
+          deadline = monotonic_now + @shutdown_timeout
+          resources = begin_shutdown(deadline)
+          return unless resources
+
+          listeners, sockets, pipe, threads = resources
+          signal_pipe(pipe)
+          listeners.each { |listener| close_socket(listener) }
+          sockets.each { |socket| close_socket(socket) }
+          join_until_deadline(threads, deadline)
+          threads.each { |thread| thread.kill if thread != Thread.current && thread.alive? }
+          pipe&.each { |io| close_socket(io) }
+        ensure
+          finish_shutdown if resources
+        end
+
+        private
+
+        class WriteTimeout < StandardError
+        end
+
+        class InvalidResponseHeader < StandardError
+        end
+
+        def positive_timeout(value, name)
+          timeout = Float(value)
+          unless timeout.positive? && timeout.finite?
+            raise ArgumentError, "#{name} must be positive"
+          end
+
+          timeout
+        rescue TypeError, ArgumentError
+          raise ArgumentError, "#{name} must be positive"
+        end
+
+        def create_listeners(address, port)
+          Socket.tcp_server_sockets(address, port)
+        end
+
+        def accept_main
+          run =
+            @mutex.synchronize do
+              if @state == :starting
+                @state = :running
+                @state_changed.broadcast
+                true
+              else
+                @state_changed.broadcast
+                false
+              end
+            end
+          accept_loop if run
+        rescue StandardError => e
+          @logger.error("HTTP accept loop failed: #{e.class}: #{e.message}") if running?
+        ensure
+          shutdown if running?
+        end
+
+        def accept_loop
+          loop do
+            selectable =
+              @mutex.synchronize do
+                if @state == :running
+                  read_pipe = @shutdown_pipe&.first
+                  @tokens.empty? ? [read_pipe] : [read_pipe, *@listeners]
+                end
+              end
+            break unless selectable
+
+            readable = IO.select(selectable)&.first
+            break unless readable
+
+            read_pipe = @mutex.synchronize { @shutdown_pipe&.first }
+            if read_pipe && readable.delete(read_pipe)
+              drain_pipe(read_pipe)
+              break unless running?
+            end
+
+            readable.each do |listener|
+              break unless running?
+              next unless reserve_client_slot
+
+              return_client_slot unless accept_and_publish_client(listener)
+            end
+          end
+        rescue Errno::EBADF, Errno::ENOTSOCK, IOError
+          nil
+        end
+
+        def reserve_client_slot
+          @tokens.pop(true)
+          true
+        rescue ThreadError
+          false
+        end
+
+        # Accepting, publishing the socket, and publishing its blocked thread are
+        # one lifecycle operation. Shutdown either sees all of them or wins first.
+        def accept_and_publish_client(listener)
+          gate = Thread::Queue.new
+          socket = nil
+          thread = nil
+
+          @mutex.synchronize do
+            return false unless @state == :running
+
+            socket = accept_client(listener)
+            return false unless socket
+
+            @client_sockets[socket] = true
+            thread = Thread.new { client_main(socket) if gate.pop }
+            @client_threads << thread
+          rescue Exception
+            @client_sockets.delete(socket)
+            close_socket(socket) if socket
+            thread&.kill
+            raise
+          end
+
+          gate << true
+          true
+        end
+
+        def accept_client(listener)
+          case socket = listener.accept_nonblock(exception: false)
+          when :wait_readable
+            nil
+          when Array
+            socket.first
+          else
+            socket
+          end
+        rescue Errno::ECONNRESET, Errno::ECONNABORTED, Errno::EPROTO, Errno::EINVAL
+          nil
+        end
+
+        def client_main(raw_socket)
+          socket = raw_socket
+          begin
+            return unless running?
+
+            if @ssl_context
+              socket = wrap_tls(raw_socket)
+              return unless publish_wrapped_socket(socket)
+            end
+            handle_client(socket)
+          rescue StandardError => e
+            @logger.error("HTTP client failed: #{e.class}: #{e.message}") if running?
+          ensure
+            unregister_socket(socket)
+            unregister_socket(raw_socket)
+            close_socket(socket)
+            close_socket(raw_socket) unless socket.equal?(raw_socket)
+            return_client_slot
+            unregister_thread(Thread.current)
+          end
+        end
+
+        def publish_wrapped_socket(socket)
+          @mutex.synchronize do
+            return false unless @state == :running
+
+            @client_sockets[socket] = true
+          end
+          true
+        end
+
+        def wrap_tls(socket)
+          require "openssl"
+
+          ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, @ssl_context)
+          ssl_socket.sync_close = true
+          Timeout.timeout(@request_timeout) { ssl_socket.accept }
+          ssl_socket
+        end
+
+        def handle_client(socket)
+          loop do
+            request = nil
+            response = nil
+            close_connection = false
+
+            begin
+              request = Request.new(socket, read_timeout: @request_timeout).parse
+              response = @handler.call(request)
+              if response.status == 405
+                close_connection = true
+              else
+                request.finish
+              end
+            rescue EndOfStream
+              break
+            rescue Error => e
+              response = error_response(e.status, e.message)
+              close_connection = true
+            rescue StandardError => e
+              @logger.error("HTTP request failed: #{e.class}: #{e.message}")
+              response = error_response(500, HTTP.status_message(500))
+              close_connection = true
+            end
+
+            break unless response
+
+            keep_alive = !close_connection && request&.method != "CONNECT" && request&.keep_alive?
+            keep_alive = write_response(socket, request, response, keep_alive: keep_alive)
+            break unless keep_alive
+          end
+        end
+
+        def error_response(status, message)
+          reason = HTTP.status_message(status)
+          Response.new(status: status, body: "#{reason}: #{message}\n")
+        end
+
+        def write_response(socket, request, response, keep_alive:)
+          output, status, keep_alive = serialize_response(request, response, keep_alive)
+          response.status = status
+          write_with_timeout(socket, output)
+          keep_alive
+        rescue WriteTimeout, Errno::EPIPE, Errno::ECONNRESET, IOError, SystemCallError
+          false
+        end
+
+        def serialize_response(request, response, keep_alive)
+          version = request&.http_version == "1.0" ? "1.0" : "1.1"
+          status = normalize_status(response.status)
+          body = response.body.to_s
+          body_forbidden = (100..199).cover?(status) || [204, 205, 304].include?(status)
+          headers = response.headers.dup
+          if body_forbidden
+            body = ""
+            headers.delete_if do |name, _value|
+              %w[content-length transfer-encoding].include?(name.to_s.downcase)
+            end
+            headers["Content-Length"] = "0" if status == 205
+          else
+            headers = {
+              "Content-Type" => "text/plain; charset=utf-8",
+              "Content-Length" => body.bytesize.to_s,
+            }.merge(headers)
+          end
+          headers["Connection"] = "close" unless keep_alive
+          headers["Connection"] = "Keep-Alive" if keep_alive && version == "1.0"
+          headers = validated_headers(headers)
+
+          output = +"HTTP/#{version} #{status} #{HTTP.status_message(status)}\r\n".b
+          headers.each { |name, value| output << "#{name}: #{value}\r\n" }
+          output << "\r\n"
+          output << body unless request&.method == "HEAD"
+          [output, status, keep_alive]
+        rescue InvalidResponseHeader => e
+          @logger.error("Invalid HTTP response header: #{e.message}")
+          body = "Internal Server Error\n"
+          output =
+            +"HTTP/#{version} 500 #{HTTP.status_message(500)}\r\n" \
+              "Content-Type: text/plain; charset=utf-8\r\n" \
+              "Content-Length: #{body.bytesize}\r\n" \
+              "Connection: close\r\n\r\n".b
+          output << body unless request&.method == "HEAD"
+          [output, 500, false]
+        end
+
+        def normalize_status(status)
+          code =
+            if status.is_a?(Integer)
+              status
+            elsif status.is_a?(String) && /\A\d{3}\z/.match?(status)
+              status.to_i
+            end
+          code && (100..599).cover?(code) ? code : 500
+        end
+
+        def validated_headers(headers)
+          seen_names = {}
+          headers.to_h do |raw_name, raw_value|
+            name = raw_name.to_s
+            normalized_name = name.downcase
+            value = raw_value.to_s
+            raise InvalidResponseHeader, "invalid name" unless HEADER_NAME.match?(name)
+            raise InvalidResponseHeader, "duplicate name #{name}" if seen_names[normalized_name]
+            if normalized_name == "transfer-encoding"
+              raise InvalidResponseHeader, "unsupported transfer-encoding"
+            end
+            if INVALID_HEADER_VALUE.match?(value)
+              raise InvalidResponseHeader, "invalid value for #{name}"
+            end
+
+            seen_names[normalized_name] = true
+            [name, value]
+          end
+        end
+
+        def write_with_timeout(socket, output)
+          deadline = monotonic_now + @write_timeout
+          offset = 0
+          while offset < output.bytesize
+            written =
+              socket.write_nonblock(
+                output.byteslice(offset, output.bytesize - offset),
+                exception: false,
+              )
+            case written
+            when Integer
+              offset += written
+            when :wait_readable
+              wait_for_io(socket, readable: true, deadline: deadline)
+            when :wait_writable
+              wait_for_io(socket, readable: false, deadline: deadline)
+            else
+              raise IOError, "response write failed"
+            end
+          end
+        end
+
+        def wait_for_io(socket, readable:, deadline:)
+          remaining = deadline - monotonic_now
+          raise WriteTimeout if remaining <= 0
+
+          ready =
+            if readable
+              IO.select([socket], nil, nil, remaining)
+            else
+              IO.select(nil, [socket], nil, remaining)
+            end
+          raise WriteTimeout unless ready
+        end
+
+        def begin_shutdown(deadline)
+          @mutex.synchronize do
+            case @state
+            when :new
+              @state = :stopped
+              @state_changed.broadcast
+              return nil
+            when :starting, :running
+              @state = :stopping
+              @state_changed.broadcast
+              listeners = @listeners
+              @listeners = []
+              sockets = @client_sockets.keys
+              pipe = @shutdown_pipe
+              threads = [@accept_thread, *@client_threads].compact.uniq
+              return listeners, sockets, pipe, threads
+            when :stopping
+              remaining = deadline - monotonic_now
+              while @state == :stopping && remaining.positive?
+                @state_changed.wait(@mutex, remaining)
+                remaining = deadline - monotonic_now
+              end
+              return nil
+            when :stopped
+              return nil
+            end
+          end
+        end
+
+        def finish_shutdown
+          @mutex.synchronize do
+            @listeners = []
+            @shutdown_pipe = nil
+            @state = :stopped
+            @state_changed.broadcast
+          end
+        end
+
+        def close_resources_locked
+          @listeners.each { |listener| close_socket(listener) }
+          @shutdown_pipe&.each { |io| close_socket(io) }
+          @listeners = []
+          @shutdown_pipe = nil
+        end
+
+        def join_until_deadline(threads, deadline)
+          threads.each do |thread|
+            next if thread == Thread.current
+
+            remaining = deadline - monotonic_now
+            break unless remaining.positive?
+
+            thread.join(remaining)
+          end
+        end
+
+        def running?
+          @mutex.synchronize { @state == :running }
+        end
+
+        def unregister_socket(socket)
+          @mutex.synchronize { @client_sockets.delete(socket) }
+        end
+
+        def unregister_thread(thread)
+          @mutex.synchronize { @client_threads.delete(thread) }
+          signal_pipe(@mutex.synchronize { @shutdown_pipe }) if running?
+        end
+
+        def return_client_slot
+          @tokens.push(nil)
+        end
+
+        def signal_pipe(pipe)
+          writer = pipe&.last
+          writer&.write_nonblock("\0") unless writer&.closed?
+        rescue IO::WaitWritable, Errno::EPIPE, IOError
+          nil
+        end
+
+        def drain_pipe(reader)
+          buffer = +""
+          nil while reader.read_nonblock(64, buffer, exception: false).is_a?(String)
+        rescue IOError, SystemCallError
+          nil
+        end
+
+        def monotonic_now
+          Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+
+        def close_socket(socket)
+          socket.close unless socket.closed?
+        rescue IOError, SystemCallError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/prometheus_exporter/server/web_server.rb
+++ b/lib/prometheus_exporter/server/web_server.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-require "webrick"
+require "logger"
+require "stringio"
 require "timeout"
 require "zlib"
-require "stringio"
+require_relative "http/basic_authenticator"
+require_relative "http/server"
 
 module PrometheusExporter::Server
   class WebServer
@@ -16,6 +18,18 @@ module PrometheusExporter::Server
         4096
       end
     private_constant :PAGESIZE
+
+    ROUTE_METHODS = {
+      "/metrics" => %w[GET HEAD OPTIONS].freeze,
+      "/ping" => %w[GET HEAD OPTIONS].freeze,
+      "/send-metrics" => %w[POST PUT OPTIONS].freeze,
+    }.freeze
+    ALL_METHODS = %w[GET HEAD POST PUT OPTIONS].freeze
+    private_constant :ROUTE_METHODS, :ALL_METHODS
+
+    NOT_FOUND_BODY =
+      "Not Found! The Prometheus Ruby Exporter only listens on /ping, /metrics and /send-metrics"
+    private_constant :NOT_FOUND_BODY
 
     def initialize(opts)
       @port = opts[:port] || PrometheusExporter::DEFAULT_PORT
@@ -48,108 +62,41 @@ module PrometheusExporter::Server
       @sessions_total.observe(0)
       @bad_metrics_total.observe(0)
 
-      @access_log, @logger = nil
-      log_target = opts[:log_target]
-
-      if @verbose
-        @access_log = [
-          [$stderr, WEBrick::AccessLog::COMMON_LOG_FORMAT],
-          [$stderr, WEBrick::AccessLog::REFERER_LOG_FORMAT],
-        ]
-        @logger = WEBrick::Log.new(log_target || $stderr)
-      else
-        @access_log = []
-        @logger = WEBrick::Log.new(log_target || "/dev/null")
-      end
-
-      @logger.info "Using Basic Authentication via #{@auth}" if @verbose && @auth
+      @logger = build_logger(opts[:log_target])
+      @logger.info("Using Basic Authentication via #{@auth}") if @verbose && @auth
 
       if %w[ALL ANY].include?(@bind)
-        @logger.info "Listening on both 0.0.0.0/:: network interfaces"
+        @logger.info("Listening on both 0.0.0.0/:: network interfaces")
         @bind = nil
       end
 
       @collector = opts[:collector] || Collector.new(logger: @logger)
+      @authenticator =
+        HTTP::BasicAuthenticator.new(path: @auth, realm: @realm, logger: @logger) if @auth
 
-      webrick_options = { Port: @port, BindAddress: @bind, Logger: @logger, AccessLog: @access_log }
-
-      if opts[:tls_cert_file] && opts[:tls_key_file]
-        require "webrick/https"
-        require "openssl"
-
-        webrick_options[:SSLEnable] = true
-        webrick_options[:SSLCertificate] = OpenSSL::X509::Certificate.new(
-          File.read(opts[:tls_cert_file]),
-        )
-        webrick_options[:SSLPrivateKey] = OpenSSL::PKey::RSA.new(File.read(opts[:tls_key_file]))
-      end
-
-      @server = WEBrick::HTTPServer.new(webrick_options)
-
-      @server.mount_proc "/" do |req, res|
-        res["Content-Type"] = "text/plain; charset=utf-8"
-        if req.path == "/metrics"
-          authenticate(req, res) if @auth
-
-          res.status = 200
-          if req.header["accept-encoding"].to_s.include?("gzip")
-            sio = StringIO.new
-            collected_metrics = metrics
-            begin
-              writer = Zlib::GzipWriter.new(sio)
-              writer.write(collected_metrics)
-            ensure
-              writer.close
-            end
-            res.body = sio.string
-            res.header["content-encoding"] = "gzip"
-          else
-            res.body = metrics
-          end
-        elsif req.path == "/send-metrics"
-          handle_metrics(req, res)
-        elsif req.path == "/ping"
-          res.body = "PONG"
-        else
-          res.status = 404
-          res.body =
-            "Not Found! The Prometheus Ruby Exporter only listens on /ping, /metrics and /send-metrics"
-        end
-      end
-    end
-
-    def handle_metrics(req, res)
-      @sessions_total.observe
-      req.body do |block|
-        begin
-          @metrics_total.observe
-          @collector.process(block)
-        rescue => e
-          @logger.error "\n\n#{e.inspect}\n#{e.backtrace}\n\n" if @verbose
-          @bad_metrics_total.observe
-          res.body = "Bad Metrics #{e}"
-          res.status = e.respond_to?(:status_code) ? e.status_code : 500
-          break
-        end
-      end
-
-      res.body = "OK"
-      res.status = 200
+      @server =
+        HTTP::Server.new(
+          bind: @bind,
+          port: @port,
+          logger: @logger,
+          max_clients: opts[:max_clients] || HTTP::Server::DEFAULT_MAX_CLIENTS,
+          request_timeout: opts[:request_timeout] || HTTP::Server::DEFAULT_REQUEST_TIMEOUT,
+          shutdown_timeout: opts[:shutdown_timeout] || HTTP::Server::DEFAULT_SHUTDOWN_TIMEOUT,
+          write_timeout: opts[:write_timeout] || HTTP::Server::DEFAULT_WRITE_TIMEOUT,
+          ssl_context: build_ssl_context(opts),
+        ) { |request| route(request) }
     end
 
     def start
-      @runner ||=
-        Thread.start do
-          begin
-            @server.start
-          rescue => e
-            @logger.error "Failed to start prometheus collector web on port #{@port}: #{e}"
-          end
-        end
+      @runner ||= @server.start
+    rescue StandardError => e
+      @logger.error("Failed to start prometheus collector web on port #{@port}: #{e}")
+      raise
     end
 
     def stop
       @server.shutdown
+      nil
     end
 
     def metrics
@@ -157,8 +104,7 @@ module PrometheusExporter::Server
       begin
         Timeout.timeout(@timeout) { metric_text = @collector.prometheus_metrics_text }
       rescue Timeout::Error
-        # we timed out ... bummer
-        @logger.error "Generating Prometheus metrics text timed out"
+        @logger.error("Generating Prometheus metrics text timed out")
       end
 
       metrics = []
@@ -176,8 +122,8 @@ module PrometheusExporter::Server
       metrics << @bad_metrics_total
 
       <<~TEXT
-      #{metrics.map(&:to_prometheus_text).join("\n\n")}
-      #{metric_text}
+        #{metrics.map(&:to_prometheus_text).join("\n\n")}
+        #{metric_text}
       TEXT
     end
 
@@ -195,12 +141,141 @@ module PrometheusExporter::Server
       gauge
     end
 
-    def authenticate(req, res)
-      htpasswd = WEBrick::HTTPAuth::Htpasswd.new(@auth)
-      basic_auth =
-        WEBrick::HTTPAuth::BasicAuth.new({ Realm: @realm, UserDB: htpasswd, Logger: @logger })
+    private
 
-      basic_auth.authenticate(req, res)
+    def build_logger(log_target)
+      logger = Logger.new(log_target || (@verbose ? $stderr : File::NULL))
+      logger.level = @verbose ? Logger::DEBUG : Logger::WARN
+      logger
+    end
+
+    def build_ssl_context(opts)
+      return unless opts[:tls_cert_file] && opts[:tls_key_file]
+
+      require "openssl"
+
+      context = OpenSSL::SSL::SSLContext.new
+      context.cert = OpenSSL::X509::Certificate.new(File.read(opts[:tls_cert_file]))
+      context.key = OpenSSL::PKey.read(File.read(opts[:tls_key_file]))
+      context
+    end
+
+    def route(request)
+      return options_response(ALL_METHODS) if request.method == "OPTIONS" && request.path == "*"
+      if request.method == "CONNECT"
+        response = HTTP::Response.new(status: 405, body: HTTP.status_message(405))
+        response["Allow"] = ALL_METHODS.join(", ")
+        return response
+      end
+
+      allowed_methods = ROUTE_METHODS[request.path]
+      return HTTP::Response.new(status: 404, body: NOT_FOUND_BODY) unless allowed_methods
+      if allowed_methods.none? { |method| method == request.method }
+        response = HTTP::Response.new(status: 405, body: HTTP.status_message(405))
+        response["Allow"] = allowed_methods.join(", ")
+        return response
+      end
+      return options_response(allowed_methods) if request.method == "OPTIONS"
+
+      case request.path
+      when "/metrics"
+        metrics_response(request)
+      when "/send-metrics"
+        handle_metrics(request)
+      when "/ping"
+        HTTP::Response.new(body: "PONG")
+      end
+    end
+
+    def options_response(methods)
+      response = HTTP::Response.new
+      response["Allow"] = methods.join(", ")
+      response
+    end
+
+    def metrics_response(request)
+      if @authenticator && !@authenticator.authenticate(request["authorization"])
+        response = HTTP::Response.new(status: 401, body: "Unauthorized")
+        response["WWW-Authenticate"] = @authenticator.challenge
+        return response
+      end
+
+      body = metrics
+      response = HTTP::Response.new(body: body)
+      if accepts_gzip?(request["accept-encoding"])
+        response.body = gzip(body)
+        response["Content-Encoding"] = "gzip"
+      end
+      response
+    end
+
+    def accepts_gzip?(header)
+      gzip_quality = nil
+      wildcard_quality = nil
+
+      header
+        .to_s
+        .split(",")
+        .each do |entry|
+          coding, *parameters = entry.split(";").map!(&:strip)
+          quality_parameter = parameters.find { |parameter| /\Aq=/i.match?(parameter) }
+          quality = quality_parameter ? parse_quality(quality_parameter.split("=", 2).last) : 1.0
+          gzip_quality = quality if coding.casecmp?("gzip")
+          wildcard_quality = quality if coding == "*"
+        end
+
+      (gzip_quality.nil? ? wildcard_quality : gzip_quality).to_f.positive?
+    end
+
+    def parse_quality(value)
+      quality = Float(value)
+      (0.0..1.0).cover?(quality) ? quality : 0.0
+    rescue ArgumentError, TypeError
+      0.0
+    end
+
+    def gzip(body)
+      output = StringIO.new
+      writer = Zlib::GzipWriter.new(output)
+      writer.write(body)
+      writer.close
+      output.string
+    end
+
+    def handle_metrics(request)
+      @sessions_total.observe
+      response = HTTP::Response.new(body: "OK")
+      failed = false
+
+      request.each_body_chunk do |chunk|
+        next if failed
+
+        begin
+          @metrics_total.observe
+          @collector.process(chunk)
+        rescue StandardError => e
+          @logger.error("\n\n#{e.inspect}\n#{e.backtrace}\n\n") if @verbose
+          @bad_metrics_total.observe
+          response.body = "Bad Metrics #{e}"
+          response.status = exception_status(e)
+          failed = true
+        end
+      end
+
+      response
+    end
+
+    def exception_status(exception)
+      return 500 unless exception.respond_to?(:status_code)
+
+      status = exception.status_code
+      return status if status.is_a?(Integer) && (100..599).cover?(status)
+      if status.is_a?(String) && /\A\d{3}\z/.match?(status)
+        status = status.to_i
+        return status if (100..599).cover?(status)
+      end
+
+      500
     end
   end
 end

--- a/prometheus_exporter.gemspec
+++ b/prometheus_exporter.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.2.0"
 
-  spec.files = Dir['README.md', 'CHANGELOG', 'LICENSE.txt', 'lib/**/*.rb', 'exe/*']
+  spec.files = Dir["README.md", "CHANGELOG", "LICENSE.txt", "lib/**/*", "exe/*"]
 
   spec.bindir = "exe"
   spec.executables = ["prometheus_exporter"]
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "webrick"
+  spec.add_dependency "logger"
 end

--- a/test/server/vendored_http_server_test.rb
+++ b/test/server/vendored_http_server_test.rb
@@ -1,0 +1,930 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "prometheus_exporter/server"
+require "fileutils"
+require "logger"
+require "net/http"
+require "openssl"
+require "open3"
+require "rbconfig"
+require "rubygems"
+require "tmpdir"
+require "zlib"
+
+class VendoredHTTPServerTest < Minitest::Test
+  class RecordingCollector
+    def initialize
+      @processed = Queue.new
+      @values = []
+      @mutex = Mutex.new
+    end
+
+    def process(value)
+      @mutex.synchronize { @values << value }
+      @processed << value
+    end
+
+    def next_value(timeout: 2)
+      Timeout.timeout(timeout) { @processed.pop }
+    end
+
+    def values
+      @mutex.synchronize { @values.dup }
+    end
+
+    def prometheus_metrics_text
+      "recorded_metric #{@mutex.synchronize { @values.length }}\n"
+    end
+  end
+
+  class BlockingCollector < RecordingCollector
+    attr_reader :entered
+
+    def initialize
+      super
+      @entered = Queue.new
+      @release = Queue.new
+    end
+
+    def process(value)
+      @entered << value
+      @release.pop
+      super
+    end
+  end
+
+  class LargeResponseCollector < RecordingCollector
+    attr_reader :rendered
+
+    def initialize(bytes)
+      super()
+      @body = "x" * bytes
+      @rendered = Queue.new
+    end
+
+    def prometheus_metrics_text
+      @rendered << true
+      @body
+    end
+  end
+
+  class StatusErrorCollector < RecordingCollector
+    def initialize(status)
+      super()
+      @status = status
+    end
+
+    def process(_value)
+      error = StandardError.new("collector rejected metrics")
+      error.define_singleton_method(:status_code) { @status }
+      error.instance_variable_set(:@status, @status)
+      raise error
+    end
+  end
+
+  def setup
+    PrometheusExporter::Metric::Base.default_prefix = ""
+    @servers = []
+    @http_servers = []
+    @sockets = []
+  end
+
+  def teardown
+    @sockets.each { |socket| socket.close unless socket.closed? }
+    @servers.reverse_each(&:stop)
+    @http_servers.reverse_each(&:shutdown)
+  end
+
+  def test_processes_delayed_and_split_chunks_before_terminal_chunk
+    collector = RecordingCollector.new
+    port = free_port
+    start_server(port: port, collector: collector)
+    socket = connect(port)
+    socket.write(
+      "POST /send-metrics HTTP/1.1\r\n" \
+        "Host: localhost\r\n" \
+        "Transfer-Encoding: chunked\r\n" \
+        "Connection: close\r\n\r\n",
+    )
+
+    first = '{"value":1}'
+    socket.write("#{first.bytesize.to_s(16)}\r\n#{first}\r\n")
+    assert_equal(first, collector.next_value, "first chunk was not processed before termination")
+
+    second = '{"value":2}'
+    framing = "#{second.bytesize.to_s(16)}\r\n#{second}\r\n"
+    framing.each_byte { |byte| socket.write(byte.chr) }
+    assert_equal(second, collector.next_value, "chunk split across writes was not reconstructed")
+
+    assert_equal([first, second], collector.values)
+    socket.write("0\r\n\r\n")
+    status, = read_response(socket)
+    assert_equal(200, status)
+  end
+
+  def test_rejects_malformed_requests_without_killing_listener
+    collector = RecordingCollector.new
+    port = free_port
+    start_server(port: port, collector: collector)
+
+    requests = {
+      400 => [
+        "GET /ping HTTP/1.1\r\nBad Header\r\n\r\n",
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nContent-Length: 1\r\n\r\n0\r\n\r\n",
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\nContent-Length: 1\r\n\r\nx",
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: nope\r\n\r\n",
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\nZ\r\n",
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nxNOPE\r\n",
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n0\r\nBad Trailer\r\n\r\n",
+      ],
+      501 => [
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: gzip\r\n\r\n",
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: gzip, chunked\r\n\r\n",
+      ],
+    }
+
+    requests.each do |expected_status, raw_requests|
+      raw_requests.each do |request|
+        socket = connect(port)
+        socket.write(request)
+        status, = read_response(socket)
+        assert_equal(expected_status, status, request.inspect)
+        socket.close
+
+        assert_ping(port)
+      end
+    end
+  end
+
+  def test_enforces_request_line_and_total_header_limits
+    port = free_port
+    start_server(port: port, collector: RecordingCollector.new)
+
+    socket = connect(port)
+    socket.write("GET /#{"a" * 2_100} HTTP/1.1\r\n\r\n")
+    status, = read_response(socket)
+    assert_equal(414, status)
+    socket.close
+
+    socket = connect(port)
+    headers = "X-Test: #{"a" * 100}\r\n" * 1_200
+    socket.write("GET /ping HTTP/1.1\r\n#{headers}\r\n")
+    status, = read_response(socket)
+    assert_equal(413, status)
+
+    assert_ping(port)
+  end
+
+  def test_basic_auth_uses_crypt_and_returns_challenge
+    Dir.mktmpdir do |directory|
+      auth_file = File.join(directory, "htpasswd")
+      File.write(auth_file, "scraper:#{"secret".crypt("pe")}\n")
+      port = free_port
+      start_server(port: port, collector: RecordingCollector.new, auth: auth_file, realm: "Metrics")
+
+      status, headers, body = raw_get(port, "/metrics")
+      assert_equal(401, status)
+      assert_equal("Basic realm=\"Metrics\"", headers["www-authenticate"])
+      assert_equal("Unauthorized", body)
+
+      wrong = ["scraper:wrong"].pack("m0")
+      status, = raw_get(port, "/metrics", { "Authorization" => "Basic #{wrong}" })
+      assert_equal(401, status)
+
+      credentials = ["scraper:secret"].pack("m0")
+      status, _, body = raw_get(port, "/metrics", { "Authorization" => "Basic #{credentials}" })
+      assert_equal(200, status)
+      assert_includes(body, "recorded_metric 0")
+    end
+  end
+
+  def test_metrics_plain_gzip_ping_and_not_found
+    port = free_port
+    start_server(port: port, collector: RecordingCollector.new)
+
+    status, headers, body = raw_get(port, "/metrics", { "Accept-Encoding" => "identity" })
+    assert_equal(200, status)
+    refute(headers.key?("content-encoding"))
+    assert_includes(body, "recorded_metric 0")
+
+    status, headers, compressed = raw_get(port, "/metrics", { "Accept-Encoding" => "gzip" })
+    assert_equal(200, status)
+    assert_equal("gzip", headers["content-encoding"])
+    assert_includes(Zlib::GzipReader.new(StringIO.new(compressed)).read, "recorded_metric 0")
+
+    status, headers, body = raw_get(port, "/metrics", { "Accept-Encoding" => "gzip;q=0, *;q=1" })
+    assert_equal(200, status)
+    refute(headers.key?("content-encoding"))
+    assert_includes(body, "recorded_metric 0")
+
+    status, headers, compressed = raw_get(port, "/metrics", { "Accept-Encoding" => "*;q=0.5" })
+    assert_equal(200, status)
+    assert_equal("gzip", headers["content-encoding"])
+    assert_includes(Zlib::GzipReader.new(StringIO.new(compressed)).read, "recorded_metric 0")
+
+    assert_ping(port)
+    status, _, body = raw_get(port, "/missing")
+    assert_equal(404, status)
+    assert_equal(
+      "Not Found! The Prometheus Ruby Exporter only listens on /ping, /metrics and /send-metrics",
+      body,
+    )
+  end
+
+  def test_http_1_0_and_1_1_keep_alive
+    port = free_port
+    start_server(port: port, collector: RecordingCollector.new)
+
+    socket = connect(port)
+    socket.write("GET /ping HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    status, headers, body = read_response(socket)
+    assert_equal([200, "PONG"], [status, body])
+    refute_equal("close", headers["connection"])
+    socket.write("GET /ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+    assert_equal(200, read_response(socket).first)
+    socket.close
+
+    socket = connect(port)
+    socket.write("GET /ping HTTP/1.0\r\nConnection: keep-alive\r\n\r\n")
+    status, headers, = read_response(socket)
+    assert_equal(200, status)
+    assert_equal("Keep-Alive", headers["connection"])
+    socket.write("GET /ping HTTP/1.0\r\nConnection: close\r\n\r\n")
+    assert_equal(200, read_response(socket).first)
+  end
+
+  def test_validates_and_ignores_all_chunked_trailers
+    collector = RecordingCollector.new
+    port = free_port
+    start_server(port: port, collector: collector)
+    payload = "metric"
+    request =
+      "POST /send-metrics HTTP/1.1\r\n" \
+        "Host: localhost\r\n" \
+        "Transfer-Encoding: chunked\r\n" \
+        "Trailer: Content-Length, X-Trace\r\n" \
+        "Connection: close\r\n\r\n" \
+        "#{payload.bytesize.to_s(16)}\r\n#{payload}\r\n" \
+        "0\r\nContent-Length: 999\r\nX-Trace: ignored\r\n\r\n"
+    socket = connect(port)
+    socket.write(request)
+
+    assert_equal(payload, collector.next_value)
+    assert_equal(200, read_response(socket).first)
+    assert_ping(port)
+  end
+
+  def test_max_clients_bounds_concurrent_connections
+    collector = RecordingCollector.new
+    port = free_port
+    start_server(port: port, collector: collector, max_clients: 1)
+
+    first = connect(port)
+    first.write(
+      "POST /send-metrics HTTP/1.1\r\n" \
+        "Host: localhost\r\n" \
+        "Transfer-Encoding: chunked\r\n" \
+        "Connection: close\r\n\r\n" \
+        "1\r\nx\r\n",
+    )
+    assert_equal("x", collector.next_value)
+
+    second = connect(port)
+    second.write("GET /ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+    refute(
+      IO.select([second], nil, nil, 0.05),
+      "second client ran while the only slot was occupied",
+    )
+
+    first.write("0\r\n\r\n")
+    assert_equal(200, read_response(first).first)
+    status, _, body = read_response(second)
+    assert_equal([200, "PONG"], [status, body])
+  end
+
+  def test_request_read_timeout_returns_408_and_listener_survives
+    port = free_port
+    start_server(port: port, collector: RecordingCollector.new, request_timeout: 0.1)
+    socket = connect(port)
+    socket.write("GET /ping HTTP/1.1\r\nX-Partial:")
+
+    assert_equal(408, read_response(socket).first)
+    assert_ping(port)
+  end
+
+  def test_stop_interrupts_partial_request_and_allows_immediate_port_reuse
+    port = free_port
+    collector = RecordingCollector.new
+    server = start_server(port: port, collector: collector, request_timeout: 30)
+    socket = connect(port)
+    socket.write(
+      "POST /send-metrics HTTP/1.1\r\n" \
+        "Host: localhost\r\n" \
+        "Transfer-Encoding: chunked\r\n\r\n" \
+        "1\r\nx\r\n" \
+        "10\r\npartial",
+    )
+    assert_equal("x", collector.next_value)
+
+    Timeout.timeout(2) { server.stop }
+    replacement = TCPServer.new("127.0.0.1", port)
+    replacement.close
+    @servers.delete(server)
+  end
+
+  def test_tls
+    Dir.mktmpdir do |directory|
+      cert_file, key_file = write_certificate(directory)
+      port = free_port
+      start_server(
+        port: port,
+        collector: RecordingCollector.new,
+        tls_cert_file: cert_file,
+        tls_key_file: key_file,
+      )
+
+      tcp = TCPSocket.new("127.0.0.1", port)
+      context = OpenSSL::SSL::SSLContext.new
+      context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      socket = OpenSSL::SSL::SSLSocket.new(tcp, context)
+      socket.sync_close = true
+      socket.connect
+      @sockets << socket
+      socket.write("GET /ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+      status, _, body = read_response(socket)
+      assert_equal([200, "PONG"], [status, body])
+    end
+  end
+
+  def test_ipv4_ipv6_and_any_wildcard
+    port = free_port
+    server = start_server(port: port, bind: "127.0.0.1", collector: RecordingCollector.new)
+    assert_ping(port, "127.0.0.1")
+    server.stop
+    @servers.delete(server)
+
+    return unless ipv6_available?
+
+    port = free_port("::1")
+    server = start_server(port: port, bind: "::1", collector: RecordingCollector.new)
+    assert_ping(port, "::1")
+    server.stop
+    @servers.delete(server)
+
+    port = free_dual_stack_port
+    start_server(port: port, bind: "ANY", collector: RecordingCollector.new)
+    assert_ping(port, "127.0.0.1")
+    assert_ping(port, "::1")
+  end
+
+  def test_body_parser_errors_escape_metrics_handler_and_force_close
+    collector = RecordingCollector.new
+    port = free_port
+    start_server(port: port, collector: collector)
+    socket = connect(port)
+    socket.write(
+      "POST /send-metrics HTTP/1.1\r\n" \
+        "Host: localhost\r\n" \
+        "Transfer-Encoding: chunked\r\n\r\n" \
+        "1\r\nx\r\nZ\r\n",
+    )
+
+    assert_equal("x", collector.next_value)
+    status, headers, = read_response(socket)
+    assert_equal(400, status)
+    assert_equal("close", headers["connection"])
+    assert_equal("", Timeout.timeout(1) { socket.read })
+  end
+
+  def test_route_method_semantics_and_options
+    collector = RecordingCollector.new
+    port = free_port
+    start_server(port: port, collector: collector)
+
+    assert_equal(
+      200,
+      raw_request(
+        port,
+        "HEAD /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        read_body: false,
+      ).first,
+    )
+    assert_equal(
+      200,
+      raw_request(
+        port,
+        "HEAD /ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        read_body: false,
+      ).first,
+    )
+
+    %w[POST PUT].each do |method|
+      status, =
+        raw_request(
+          port,
+          "#{method} /send-metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
+        )
+      assert_equal(200, status)
+      assert_equal("x", collector.next_value)
+    end
+
+    {
+      "POST /metrics" => "GET, HEAD, OPTIONS",
+      "GET /send-metrics" => "POST, PUT, OPTIONS",
+      "DELETE /ping" => "GET, HEAD, OPTIONS",
+      "BREW /metrics" => "GET, HEAD, OPTIONS",
+    }.each do |request_line, allow|
+      status, headers, =
+        raw_request(
+          port,
+          "#{request_line} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        )
+      assert_equal(405, status)
+      assert_equal(allow, headers["allow"])
+    end
+
+    {
+      "/metrics" => "GET, HEAD, OPTIONS",
+      "/ping" => "GET, HEAD, OPTIONS",
+      "/send-metrics" => "POST, PUT, OPTIONS",
+      "*" => "GET, HEAD, POST, PUT, OPTIONS",
+    }.each do |target, allow|
+      status, headers, =
+        raw_request(
+          port,
+          "OPTIONS #{target} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        )
+      assert_equal(200, status)
+      assert_equal(allow, headers["allow"])
+    end
+  end
+
+  def test_host_method_token_options_star_and_connect_validation
+    port = free_port
+    start_server(port: port, collector: RecordingCollector.new)
+
+    invalid_requests = [
+      "GET /ping HTTP/1.1\r\nConnection: close\r\n\r\n",
+      "GET /ping HTTP/1.1\r\nHost: one\r\nHost: two\r\nConnection: close\r\n\r\n",
+      "GET /ping HTTP/1.1\r\nHost: user@localhost\r\nConnection: close\r\n\r\n",
+      "GET /ping HTTP/1.1\r\nHost: bad..host\r\nConnection: close\r\n\r\n",
+      "GET /ping HTTP/1.1\r\nHost: localhost:99999\r\nConnection: close\r\n\r\n",
+      "GE@T /ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+      "GET * HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    ]
+    invalid_requests.each { |request| assert_equal(400, raw_request(port, request).first, request) }
+
+    status, headers, =
+      raw_request(
+        port,
+        "CONNECT localhost:443 HTTP/1.1\r\nHost: localhost:443\r\nConnection: close\r\n\r\n",
+      )
+    assert_equal(405, status)
+    assert_equal("GET, HEAD, POST, PUT, OPTIONS", headers["allow"])
+    assert_equal(200, raw_request(port, "GET /ping HTTP/1.0\r\nConnection: close\r\n\r\n").first)
+  end
+
+  def test_realm_is_escaped_and_control_characters_are_rejected
+    Dir.mktmpdir do |directory|
+      auth_file = File.join(directory, "htpasswd")
+      File.write(auth_file, "scraper:#{"secret".crypt("pe")}\n")
+      assert_raises(ArgumentError) do
+        PrometheusExporter::Server::WebServer.new(
+          port: free_port,
+          bind: "127.0.0.1",
+          collector: RecordingCollector.new,
+          auth: auth_file,
+          realm: "metrics\r\nX-Injected: yes",
+        )
+      end
+
+      port = free_port
+      start_server(
+        port: port,
+        collector: RecordingCollector.new,
+        auth: auth_file,
+        realm: 'metrics \\ "private"',
+      )
+      _, headers, = raw_get(port, "/metrics")
+      assert_equal('Basic realm="metrics \\\\ \\"private\\""', headers["www-authenticate"])
+    end
+  end
+
+  def test_invalid_application_response_headers_are_never_serialized
+    [
+      ["Bad Name", "safe"],
+      ["X-Test", "safe\r\nX-Injected: yes"],
+      ["X-Test", "bad\u0001value"],
+      %w[Transfer-Encoding chunked],
+    ].each do |name, value|
+      port = free_port
+      server =
+        start_http_server(port: port) do
+          response = PrometheusExporter::Server::HTTP::Response.new
+          response[name] = value
+          response
+        end
+      status, headers, body = raw_get(port, "/")
+      assert_equal(500, status)
+      refute(headers.key?("x-injected"))
+      assert_equal("Internal Server Error\n", body)
+      server.shutdown
+      @http_servers.delete(server)
+    end
+  end
+
+  def test_body_forbidden_statuses_never_serialize_payloads
+    [101, 204, 205, 304].each do |response_status|
+      port = free_port
+      server =
+        start_http_server(port: port) do
+          response =
+            PrometheusExporter::Server::HTTP::Response.new(
+              status: response_status,
+              body: "forbidden",
+            )
+          response["Transfer-Encoding"] = "chunked"
+          response
+        end
+
+      status, headers, body = raw_get(port, "/")
+      assert_equal(response_status, status)
+      assert_equal("", body)
+      refute(headers.key?("transfer-encoding"))
+      if response_status == 205
+        assert_equal("0", headers["content-length"])
+      else
+        refute(headers.key?("content-length"))
+      end
+
+      server.shutdown
+      @http_servers.delete(server)
+    end
+  end
+
+  def test_custom_exception_status_is_safe
+    port = free_port
+    start_server(port: port, collector: StatusErrorCollector.new(429))
+    status_line =
+      raw_request(
+        port,
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
+        include_status_line: true,
+      ).last
+    assert_match(%r{\AHTTP/1\.1 429 Too Many Requests\r\n}, status_line)
+
+    port = free_port
+    start_server(port: port, collector: StatusErrorCollector.new(599))
+    status_line =
+      raw_request(
+        port,
+        "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
+        include_status_line: true,
+      ).last
+    assert_match(%r{\AHTTP/1\.1 599 Unknown Status\r\n}, status_line)
+
+    [99, 600, "not-a-status"].each do |invalid_status|
+      port = free_port
+      start_server(port: port, collector: StatusErrorCollector.new(invalid_status))
+      status, =
+        raw_request(
+          port,
+          "POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
+        )
+      assert_equal(500, status)
+    end
+  end
+
+  def test_lifecycle_has_no_prestart_listener_and_reports_bind_failure
+    port = free_port
+    server =
+      PrometheusExporter::Server::WebServer.new(
+        port: port,
+        bind: "127.0.0.1",
+        collector: RecordingCollector.new,
+      )
+    http_server = server.instance_variable_get(:@server)
+    assert_empty(http_server.listeners)
+    probe = TCPServer.new("127.0.0.1", port)
+    probe.close
+
+    blocker = TCPServer.new("127.0.0.1", port)
+    assert_raises(Errno::EADDRINUSE) { server.start }
+    assert_empty(http_server.listeners)
+    blocker.close
+
+    stopped =
+      PrometheusExporter::Server::WebServer.new(
+        port: free_port,
+        bind: "127.0.0.1",
+        collector: RecordingCollector.new,
+      )
+    stopped.stop
+    assert_raises(RuntimeError) { stopped.start }
+  ensure
+    blocker&.close
+  end
+
+  def test_shutdown_can_win_startup_handshake_without_start_after_shutdown
+    port = free_port
+    server =
+      PrometheusExporter::Server::HTTP::Server.new(
+        bind: "127.0.0.1",
+        port: port,
+        logger: Logger.new(File::NULL),
+      ) { PrometheusExporter::Server::HTTP::Response.new }
+    @http_servers << server
+    entered = Queue.new
+    release = Queue.new
+    original_accept_main = server.method(:accept_main)
+    server.define_singleton_method(:accept_main) do
+      entered << true
+      release.pop
+      original_accept_main.call
+    end
+
+    start_result = Queue.new
+    starter =
+      Thread.new do
+        server.start
+        start_result << :started
+      rescue StandardError => e
+        start_result << e
+      end
+    Timeout.timeout(1) { entered.pop }
+    stopper = Thread.new { server.shutdown }
+    wait_for_http_state(server, :stopping)
+    release << true
+    starter.join
+    stopper.join
+
+    result = start_result.pop
+    assert_instance_of(RuntimeError, result)
+    assert_match(/shut down during startup/, result.message)
+    assert_raises(RuntimeError) { server.start }
+    replacement = TCPServer.new("127.0.0.1", port)
+    replacement.close
+  end
+
+  def test_shutdown_wins_before_published_client_can_process
+    collector = RecordingCollector.new
+    port = free_port
+    server = start_server(port: port, collector: collector, shutdown_timeout: 0.5)
+    http_server = server.instance_variable_get(:@server)
+    entered = Queue.new
+    release = Queue.new
+    original_client_main = http_server.method(:client_main)
+    http_server.define_singleton_method(:client_main) do |socket|
+      entered << true
+      release.pop
+      original_client_main.call(socket)
+    end
+
+    socket = connect(port)
+    socket.write("POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\n\r\nx")
+    Timeout.timeout(1) { entered.pop }
+    stopper = Thread.new { server.stop }
+    wait_for_http_state(http_server, :stopping)
+    release << true
+    stopper.join
+
+    assert_empty(collector.values)
+    replacement = TCPServer.new("127.0.0.1", port)
+    replacement.close
+    @servers.delete(server)
+  end
+
+  def test_shutdown_timeout_bounds_blocked_application
+    collector = BlockingCollector.new
+    port = free_port
+    timeout = 0.05
+    server = start_server(port: port, collector: collector, shutdown_timeout: timeout)
+    socket = connect(port)
+    socket.write("POST /send-metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\n\r\nx")
+    Timeout.timeout(1) { collector.entered.pop }
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    server.stop
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_operator(elapsed, :>=, timeout * 0.8)
+    assert_operator(elapsed, :<, timeout + 0.1)
+    replacement = TCPServer.new("127.0.0.1", port)
+    replacement.close
+    @servers.delete(server)
+  end
+
+  def test_write_timeout_releases_only_client_slot_from_slow_reader
+    collector = LargeResponseCollector.new(32 * 1024 * 1024)
+    port = free_port
+    start_server(
+      port: port,
+      collector: collector,
+      max_clients: 1,
+      write_timeout: 0.05,
+      shutdown_timeout: 0.1,
+    )
+    slow = connect(port)
+    slow.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, 1024)
+    slow.write(
+      "GET /metrics HTTP/1.1\r\n" \
+        "Host: localhost\r\n" \
+        "Accept-Encoding: identity\r\n" \
+        "Connection: close\r\n\r\n",
+    )
+    Timeout.timeout(1) { collector.rendered.pop }
+
+    second = connect(port)
+    second.write("GET /ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+    status, _, body = Timeout.timeout(1) { read_response(second) }
+    assert_equal([200, "PONG"], [status, body])
+  end
+
+  def test_built_gem_loads_with_declared_dependencies_and_without_webrick
+    refute(Object.const_defined?(:WEBrick, false))
+    root = File.expand_path("../..", __dir__)
+    logger_package = Gem::Specification.find_by_name("logger").cache_file
+    assert_path_exists(logger_package)
+
+    Dir.mktmpdir do |directory|
+      gem_home = File.join(directory, "gems")
+      package = File.join(directory, "prometheus_exporter.gem")
+      build_output, build_status =
+        Open3.capture2e(
+          RbConfig.ruby,
+          "-S",
+          "gem",
+          "build",
+          "prometheus_exporter.gemspec",
+          "--output",
+          package,
+          chdir: root,
+        )
+      assert(build_status.success?, build_output)
+
+      env =
+        ENV
+          .each_key
+          .grep(/\ABUNDLE/)
+          .to_h { |name| [name, nil] }
+          .merge("GEM_HOME" => gem_home, "GEM_PATH" => gem_home, "RUBYLIB" => nil, "RUBYOPT" => nil)
+      [logger_package, package].each do |gem_file|
+        output, status =
+          Open3.capture2e(
+            env,
+            RbConfig.ruby,
+            "-S",
+            "gem",
+            "install",
+            "--local",
+            "--no-document",
+            "--install-dir",
+            gem_home,
+            "--ignore-dependencies",
+            gem_file,
+          )
+        assert(status.success?, output)
+      end
+
+      script = <<~RUBY
+        spec = Gem::Specification.find_by_name("prometheus_exporter")
+        abort "logger is not a runtime dependency" unless spec.runtime_dependencies.any? { |dependency| dependency.name == "logger" }
+        abort "webrick is still a dependency" if spec.runtime_dependencies.any? { |dependency| dependency.name == "webrick" }
+        abort "webrick is installed" unless Gem::Specification.find_all_by_name("webrick").empty?
+        require "prometheus_exporter"
+        require "prometheus_exporter/server"
+        abort "WEBrick constant defined" if Object.const_defined?(:WEBrick, false)
+        abort "not loaded from installed gem" unless $LOADED_FEATURES.grep(/prometheus_exporter/).all? { |path| path.start_with?(ENV.fetch("GEM_HOME")) }
+        puts "isolated built gem load ok"
+      RUBY
+      output, status = Open3.capture2e(env, RbConfig.ruby, "-e", script, chdir: directory)
+      assert(status.success?, output)
+      assert_equal("isolated built gem load ok\n", output)
+    end
+  end
+
+  private
+
+  def start_server(port:, collector:, bind: "127.0.0.1", **options)
+    server =
+      PrometheusExporter::Server::WebServer.new(
+        { port: port, bind: bind, collector: collector }.merge(options),
+      )
+    @servers << server
+    server.start
+    server
+  end
+
+  def start_http_server(port:, **options, &handler)
+    server =
+      PrometheusExporter::Server::HTTP::Server.new(
+        bind: "127.0.0.1",
+        port: port,
+        logger: Logger.new(File::NULL),
+        **options,
+        &handler
+      )
+    @http_servers << server
+    server.start
+    server
+  end
+
+  def connect(port, host = "127.0.0.1")
+    socket = TCPSocket.new(host, port)
+    @sockets << socket
+    socket
+  end
+
+  def raw_get(port, path, request_headers = {}, host: "127.0.0.1")
+    headers = { "Host" => "localhost", "Connection" => "close" }.merge(request_headers)
+    wire_headers = headers.map { |name, value| "#{name}: #{value}\r\n" }.join
+    raw_request(port, "GET #{path} HTTP/1.1\r\n#{wire_headers}\r\n", host: host)
+  end
+
+  def raw_request(port, request, host: "127.0.0.1", read_body: true, include_status_line: false)
+    socket = connect(port, host)
+    socket.write(request)
+    read_response(socket, read_body: read_body, include_status_line: include_status_line)
+  ensure
+    socket&.close
+  end
+
+  def read_response(socket, read_body: true, include_status_line: false)
+    status_line = Timeout.timeout(2) { socket.gets }
+    raise "connection closed without response" unless status_line
+
+    status = status_line.split(" ", 3)[1].to_i
+    headers = {}
+    while (line = socket.gets) && line != "\r\n"
+      name, value = line.split(":", 2)
+      headers[name.downcase] = value.strip
+    end
+    length = Integer(headers.fetch("content-length", "0"), 10)
+    body = !read_body || length.zero? ? "" : socket.read(length)
+    response = [status, headers, body]
+    response << status_line if include_status_line
+    response
+  end
+
+  def assert_ping(port, host = "127.0.0.1")
+    status, _, body = raw_get(port, "/ping", host: host)
+    assert_equal([200, "PONG"], [status, body])
+  end
+
+  def wait_for_http_state(server, expected)
+    mutex = server.instance_variable_get(:@mutex)
+    state_changed = server.instance_variable_get(:@state_changed)
+    Timeout.timeout(1) do
+      mutex.synchronize do
+        state_changed.wait(mutex) while server.instance_variable_get(:@state) != expected
+      end
+    end
+  end
+
+  def free_port(host = "127.0.0.1")
+    server = TCPServer.new(host, 0)
+    server.addr[1]
+  ensure
+    server&.close
+  end
+
+  def ipv6_available?
+    server = TCPServer.new("::1", 0)
+    true
+  rescue Errno::EADDRNOTAVAIL, Errno::EAFNOSUPPORT
+    false
+  ensure
+    server&.close
+  end
+
+  def free_dual_stack_port
+    loop do
+      port = free_port
+      server = TCPServer.new("::1", port)
+      server.close
+      return port
+    rescue Errno::EADDRINUSE
+      next
+    end
+  end
+
+  def write_certificate(directory)
+    key = OpenSSL::PKey::RSA.new(2048)
+    certificate = OpenSSL::X509::Certificate.new
+    certificate.version = 2
+    certificate.serial = 1
+    certificate.subject = OpenSSL::X509::Name.parse("/CN=localhost")
+    certificate.issuer = certificate.subject
+    certificate.public_key = key.public_key
+    certificate.not_before = Time.now - 60
+    certificate.not_after = Time.now + 3600
+    certificate.sign(key, OpenSSL::Digest.new("SHA256"))
+
+    cert_file = File.join(directory, "cert.pem")
+    key_file = File.join(directory, "key.pem")
+    File.write(cert_file, certificate.to_pem)
+    File.write(key_file, key.to_pem)
+    [cert_file, key_file]
+  end
+end

--- a/test/server/web_server_test.rb
+++ b/test/server/web_server_test.rb
@@ -31,10 +31,10 @@ class PrometheusExporterTest < Minitest::Test
       passwd: "test_password",
     }
 
-    # Create an htpasswd file for basic auth
-    htpasswd = WEBrick::HTTPAuth::Htpasswd.new(@auth_config[:file])
-    htpasswd.set_passwd(@auth_config[:realm], @auth_config[:user], @auth_config[:passwd])
-    htpasswd.flush
+    # Create an Apache-compatible crypt htpasswd file directly; server tests
+    # must not load the external webrick gem.
+    encrypted_password = @auth_config[:passwd].crypt("pe")
+    File.write(@auth_config[:file], "#{@auth_config[:user]}:#{encrypted_password}\n")
   end
 
   def teardown


### PR DESCRIPTION
## Summary

Third alternative to:

- #375 — custom bounded socket server
- #376 — embedded Puma plus a finite-request client protocol

This removes the external `webrick` gem dependency while preserving the released client protocol exactly. It vendors a heavily pruned, fully re-namespaced HTTP implementation derived from current WEBrick master.

There is no client-first rollout, batching policy, or request amplification: existing clients keep one long-lived chunked `POST /send-metrics` open and every metric chunk is processed immediately.

## Size and provenance

The focused vendored implementation is three Ruby files:

- request parsing and streaming body handling
- listener/client lifecycle and response framing
- Basic authentication and crypt htpasswd loading

Measured with `pygount`, they contain **802 code LOC** (**982 physical lines**). For comparison, the installed WEBrick 1.9.2 `lib/` tree is about 4,090 code LOC.

The code is derived from ruby/webrick master commit [`25b0e9206bf5991c6274893d53c428d23b3f2292`](https://github.com/ruby/webrick/commit/25b0e9206bf5991c6274893d53c428d23b3f2292), including its latest trailer hardening. Copyright/source attribution and the upstream BSD-2-Clause license are shipped in `VENDORED_WEBRICK_LICENSE.txt` and retained in source headers.

Everything is namespaced under `PrometheusExporter::Server::HTTP`; loading the gem does not define `WEBrick`.

## Preserved behavior

- Exact released `PrometheusExporter::Client` wire protocol; `client.rb` is unchanged
- Incremental chunk processing before the terminal zero chunk
- `/metrics`, gzip negotiation, `/ping`, `/send-metrics`, and existing 404 body
- HTTP/1.0 and HTTP/1.1 keep-alive
- IPv4, IPv6, `ALL`, and `ANY` bindings
- TLS certificate/private-key serving
- Basic auth with Apache-compatible crypt htpasswd files and configured realm
- Ruby 3.2 through Ruby 4.0

## Deliberately retained security boundaries

- 2,083-byte request-line and 112 KiB aggregate-header limits
- Strict method/header/Host validation
- Duplicate or invalid `Content-Length` rejection
- `Transfer-Encoding` plus `Content-Length` smuggling rejection
- Chunked-only request transfer coding with strict chunk framing
- Trailer syntax validation and complete trailer discard
- Bounded concurrent clients
- Bounded request reads and response writes
- Synchronized startup/shutdown state machine
- No pre-start listener descriptors to leak across `fork`
- Atomic accepted-client publication relative to shutdown
- Bounded shutdown even if collector code blocks
- Response status/header validation and Basic-auth realm injection protection

## Dependency change

```diff
- webrick
+ logger
```

`logger` is declared explicitly because it is no longer a default gem on Ruby 4. No additional HTTP/runtime framework is introduced.

## Verification

Final local verification on Ruby 3.4:

- **186 tests, 521 assertions, zero failures/errors/skips**
- Focused vendored HTTP suite: **25 tests, 169 assertions**
- Syntax Tree clean
- RuboCop clean
- `git diff --check` clean
- Gem build passed
- Isolated built-gem install/load passed with declared dependencies installed and WEBrick absent
- Vendored files and license confirmed in the package

The implementation and full suite were also exercised repeatedly on Ruby 3.2 and Ruby 4.0 during hardening.
